### PR TITLE
Drop Python 3.5 support.

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -20,7 +20,6 @@ stages:
 - template: stage-test.yml
   parameters:
     pythonVersions:
-      - '3.5'
       - '3.6'
       - '3.7'
       - '3.8'

--- a/.azure-pipelines/deploy.yml
+++ b/.azure-pipelines/deploy.yml
@@ -26,7 +26,6 @@ stages:
 - template: stage-test.yml
   parameters:
     pythonVersions:
-      - '3.5'
       - '3.6'
       - '3.7'
       - '3.8'
@@ -34,7 +33,6 @@ stages:
 - template: stage-deploy.yml
   parameters:
     pythonVersions:
-      - '3.5'
       - '3.6'
       - '3.7'
       - '3.8'

--- a/CHANGES/24.removal
+++ b/CHANGES/24.removal
@@ -1,0 +1,1 @@
+Dropped support for Python 3.5; only 3.6, 3.7 and 3.8 are supported going forward.

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Installation
 
    $ pip install frozenlist
 
-The library requires Python 3.5.3 or newer.
+The library requires Python 3.6 or newer.
 
 
 Documentation
@@ -76,7 +76,7 @@ Feel free to post your questions and ideas here.
 Requirements
 ============
 
-- Python >= 3.5.3
+- Python >= 3.6
 
 License
 =======

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@ Installation
 
    $ pip install frozenlist
 
-The library requires Python 3.5.3 or newer.
+The library requires Python 3.6 or newer.
 
 
 Documentation
@@ -54,7 +54,7 @@ Feel free to post your questions and ideas here.
 Requirements
 ============
 
-- Python >= 3.5.3
+- Python >= 3.6
 
 License
 =======

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ except ImportError:
     CYTHON = False
 
 
-if sys.version_info < (3, 5, 3):
-    raise RuntimeError("frozenlist 1.x requires Python 3.5.3+")
+if sys.version_info < (3, 6):
+    raise RuntimeError("frozenlist 1.x requires Python 3.6+")
 
 
 NO_EXTENSIONS = (
@@ -82,7 +82,6 @@ setup(
         'Intended Audience :: Developers',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Development Status :: 5 - Production/Stable',
@@ -107,7 +106,7 @@ setup(
     license='Apache 2',
     packages=['frozenlist'],
     ext_modules=ext_modules,
-    python_requires='>=3.5.3',
+    python_requires='>=3.6',
     install_requires=install_requires,
     include_package_data=True,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 
-envlist = check, clean, {py35,py36,py37}-{cython,pure}, report
+envlist = check, clean, {py36,py37,py38}-{cython,pure}, report
 
 [testenv]
 
@@ -19,9 +19,9 @@ setenv =
     pure: FROZENLIST_NO_EXTENSIONS = 1
 
 basepython:
-    py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 
 [testenv:check]
 
@@ -63,4 +63,4 @@ whitelist_externals =
     echo
 
 basepython:
-    python3.6
+    python3.7


### PR DESCRIPTION
aiohttp 4.0 has dropped support for 3.5, so we can do so too.

Since we only ever released a 1.0.0a this shouldn't cause support issues.