### PR TITLE
Hash

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,7 @@ Traceback (most recent call last):
     raise RuntimeError("Cannot modify frozen list.")
 RuntimeError: Cannot modify frozen list.
 
+FrozenList is also hashable, but only when frozen. Otherwise it also throws a RuntimeError.
 
 Installation
 ------------

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -70,6 +70,11 @@ class FrozenList(MutableSequence):
         return '<FrozenList(frozen={}, {!r})>'.format(self._frozen,
                                                       self._items)
 
+    def __hash__(self):
+        if self.frozen:
+            return hash(tuple(self))
+        else:
+            raise RuntimeError("Cannot hash unfrozen list")
 
 PyFrozenList = FrozenList
 

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -71,10 +71,10 @@ class FrozenList(MutableSequence):
                                                       self._items)
 
     def __hash__(self):
-        if self.frozen:
+        if self._frozen:
             return hash(tuple(self))
         else:
-            raise RuntimeError("Cannot hash unfrozen list")
+            raise RuntimeError("Cannot hash unfrozen list.")
 
 PyFrozenList = FrozenList
 

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -215,6 +215,17 @@ class FrozenListMixin:
             _list.append(3)
         assert _list == [1, 2]
 
+    def test_hash(self) -> None:
+        _list = self.FrozenList([1, 2])
+        with pytest.raises(RuntimeError):
+            hash(_list)
+
+    def test_hash_frozen(self) -> None:
+        _list = self.FrozenList([1, 2])
+        _list.freeze()
+        h = hash(_list)
+        assert h == hash((1,2))
+
     def test_count(self) -> None:
         _list = self.FrozenList([1, 2])
         assert _list.count(1) == 1


### PR DESCRIPTION
## What do these changes do?

Added `__hash__` to FrozenList. Normal python lists are not hashable. FrozenList is hashable only when it is frozen, otherwise it throws a RuntimeError.

## Are there changes in behavior for the user?

Frozen FrozenLists can now be used as dictionary keys.

## Related issue number

N/A.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modifications, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep the list in alphabetical order, the file is sorted by name. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
