### PR TITLE
Do not install C sources with binary distributions

### DIFF
--- a/CHANGES/250.bugfix
+++ b/CHANGES/250.bugfix
@@ -1,0 +1,1 @@
+Do not install C sources with binary distributions.

--- a/setup.py
+++ b/setup.py
@@ -87,4 +87,5 @@ setup(
     python_requires='>=3.6',
     install_requires=install_requires,
     include_package_data=True,
+    exclude_package_data={"": ["*.c"]},
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Prevent C sources (`_frozenlist.c`) from being included in binary distributions such as wheels, without affecting Cython sources (`_frozenlist.pyx`) or source distributions.

<!-- Please give a short brief about these changes. -->

Adds
```python
    exclude_package_data={"": [".c"]},
```
to `setup(…)` in `setup.py`.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Nothing changes except that the binary wheels are smaller because they do not contain `_frozenlist.c`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
https://github.com/aio-libs/frozenlist/issues/250

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist **This doesn’t seem necessary.**
- [ ] Documentation reflects the changes **No changes seem necessary.**
- [ ] If you provide code modifications, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep the list in alphabetical order, the file is sorted by name. 
  * **This contribution is trivial, so this doesn’t seem necessary, but I can add it if  desired.**
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
