### PR TITLE
fix(ci): remove deprecated set-output command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"    # - name: Cache
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: Cache PyPI
       uses: actions/cache@v3
       with:

--- a/CHANGES/342.bugfix
+++ b/CHANGES/342.bugfix
@@ -1,0 +1,1 @@
+Removed deprecated `::set-output` command from GitHub actions workflow


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix the CI Github actions workflow, which was using a deprecated command. https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
It should also fix #342 as it would continue to publish the 3.11 wheels.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#342 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modifications, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep the list in alphabetical order, the file is sorted by name.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
