### PR TITLE
CI: detect test matrix failure correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,10 +120,12 @@ jobs:
     name: Test matrix status
     runs-on: ubuntu-latest
     needs: [test]
+    if: always()
     steps:
-      - name: Check build matrix status
-        if: needs.test.result != 'success'
-        run: exit 1
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}
 
   pre-deploy:
     name: Pre-Deploy

--- a/CHANGES/327.misc
+++ b/CHANGES/327.misc
@@ -1,0 +1,1 @@
+Updated the CI runs to better check for test results and to avoid deprecated syntax.


### PR DESCRIPTION
We were missing `always()`, and use the alls-green action to verify the status of the test matrix jobs. Without `always()` the check step was being skipped whenever a test failed. :facepalm:

Fixes #327
