### PR TITLE
CI: use a fictional version when running towncrier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         pip install -r requirements/doc.txt
     - name: Run docs spelling
       run: |
-        towncrier --yes
+        towncrier build --yes --version 99.99.99
         make doc-spelling
     - name: Prepare twine checker
       run: |


### PR DESCRIPTION
Otherwise, towncrier exits with an exception when the current version has already been listed.
