### PR TITLE
Update check-jsonschema URL and version to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,8 +87,8 @@ repos:
     - 'SC2086:'
     - -ignore
     - 'SC1004:'
-- repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.10.0
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.19.2
   hooks:
   - id: check-github-actions
 ci:


### PR DESCRIPTION
I already introduced myself to aio-libs in https://github.com/aio-libs/pytest-aiohttp/pull/48, so I'm just doing more of the same here.

As in that case, I don't know if the `ci.skip` config is still needed, but I'm not suggesting removing it because there isn't enough evidence to make me confident that it isn't there on purpose.