### PR TITLE
ci: use libenchant-2-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         make lint
     - name: Install spell checker
       run: |
-        sudo apt install libenchant-dev
+        sudo apt install libenchant-2-dev
         pip install -r requirements/doc.txt
     - name: Run docs spelling
       run: |


### PR DESCRIPTION
GH actions moved to Ubuntu 22.04, so update to use libenchant-2-dev.
