### PR TITLE
Remove unused typing.Tuple import

### DIFF
--- a/CHANGES/411.bugfix
+++ b/CHANGES/411.bugfix
@@ -1,0 +1,1 @@
+Removed an unused typing.Tuple import

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -3,7 +3,7 @@ import sys
 import types
 from collections.abc import MutableSequence
 from functools import total_ordering
-from typing import Tuple, Type
+from typing import Type
 
 __version__ = "1.3.3"
 


### PR DESCRIPTION
The Tuple type hint is only used in a comment and can safely be removed.
