### PR TITLE
ci: Update RTD configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,10 @@
 version: 2
 
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: '3.10'
 
 python:
-  version: 3.10
   install:
     - requirements: requirements/doc.txt


### PR DESCRIPTION
The python.version option is considered legacy; use the new build.os and build.tools.python options to make sure we can build the docs correctly (sphinx 6.x needs Python 3.8 or newer).
