### PR TITLE
Upgrade cython to 3.0.0b1, add 3.12 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,17 +67,28 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        pyver: ['3.8', '3.9', '3.10', '~3.11.0-0']
+        pyver: ['3.8', '3.9', '3.10', '3.11']
         no-extensions: ['', 'Y']
+        experimental: [false]
         os: [ubuntu, macos, windows]
         exclude:
           - os: macos
             no-extensions: 'Y'
           - os: windows
             no-extensions: 'Y'
+        include:
+          - pyver: 3.12-dev
+            no-extensions: ''
+            experimental: true
+            os: ubuntu
+          - pyver: 3.12-dev
+            no-extensions: 'Y'
+            experimental: true
+            os: ubuntu
       fail-fast: false
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 15
+    continue-on-error: ${{ matrix.experimental }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/CHANGES/433.misc
+++ b/CHANGES/433.misc
@@ -1,0 +1,1 @@
+Use cython 3.0.0b1 (or newer), fixing Python 3.12 compatibility.

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,6 +1,6 @@
 build==0.10.0
 coverage==7.2.2
-cython==0.29.33
+cython==3.0.0b1
 mypy==1.1.1; implementation_name=="cpython"
 pre-commit==3.1.1
 pytest==7.2.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 
-envlist = check, clean, {py38,py39,py310}-{cython,pure}, report
+envlist = check, clean, {py38,py39,py310,py311,py312}-{cython,pure}, report
 
 [testenv]
 


### PR DESCRIPTION
This release is compatible with Python 3.12a05 (and up).  While here, extend
the tox configuration to also cover 3.11 and 3.12, and have GitHub test against
3.12.

## Related issue number

Fixes #433

