### PR TITLE
docs: validate docs more strictly, fix references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,11 +77,11 @@ clean:
 	@rm -rf frozenlist.egg-info
 
 doc:
-	@make -C docs html SPHINXOPTS="-W -E"
+	@make -C docs html SPHINXOPTS="-W --keep-going -n -E"
 	@echo "open file://`pwd`/docs/_build/html/index.html"
 
 doc-spelling:
-	@make -C docs spelling SPHINXOPTS="-W -E"
+	@make -C docs spelling SPHINXOPTS="-W --keep-going -n -E"
 
 install:
 	@pip install -U 'pip'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ extensions = [
 
 with suppress(ImportError):
     # spelling extension is optional, only add it when installed
-    import sphinxcontrib.spelling  # noqa
+    import sphinxcontrib.spelling  # noqa # type: ignore
 
     extensions.append("sphinxcontrib.spelling")
 
@@ -139,7 +139,9 @@ html_theme = "aiohttp_theme"
 # documentation.
 html_theme_options = {
     "logo": None,
-    "description": "A list-like structure which implements collections.abc.MutableSequence",
+    "description": (
+        "A list-like structure which implements collections.abc.MutableSequence"
+    ),
     "canonical_url": "http://frozenlist.readthedocs.org/en/stable/",
     "github_user": "aio-libs",
     "github_repo": "frozenlist",
@@ -154,7 +156,10 @@ html_theme_options = {
             "alt": "Github CI status for master branch",
         },
         {
-            "image": "https://codecov.io/github/aio-libs/frozenlist/coverage.svg?branch=master",
+            "image": (
+                "https://codecov.io/github/aio-libs/frozenlist/coverage.svg"
+                "?branch=master"
+            ),
             "target": "https://codecov.io/github/aio-libs/frozenlist",
             "height": "20",
             "alt": "Code coverage status",
@@ -166,7 +171,10 @@ html_theme_options = {
             "alt": "Latest PyPI package version",
         },
         {
-            "image": "https://img.shields.io/discourse/topics?server=https%3A%2F%2Faio-libs.discourse.group%2F",
+            "image": (
+                "https://img.shields.io/discourse/topics"
+                "?server=https%3A%2F%2Faio-libs.discourse.group%2F"
+            ),
             "target": "https://aio-libs.discourse.group/",
             "height": "20",
             "alt": "Discourse group for io-libs",
@@ -343,3 +351,7 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
+
+# -- Strictness options --------------------------------------------------
+nitpicky = True
+nitpick_ignore = []

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,11 +4,11 @@ frozenlist
 A list-like structure which implements
 :class:`collections.abc.MutableSequence`.
 
-The list is *mutable* until :meth:`FrozenList.freeze` is called,
+The list is *mutable* until :meth:`~frozenlist.FrozenList.freeze` is called,
 after which list modifications raise :exc:`RuntimeError`. A
-:class:`FrozenList` instance is hashable, but only when frozen.
-Attempts to hash a non-frozen instance will result in a
-:exc:`RuntimeError` exception.
+:class:`~frozenlist.FrozenList` instance is hashable, but only when frozen.
+Attempts to hash a non-frozen instance will result in a :exc:`RuntimeError`
+exception.
 
 API
 ---


### PR DESCRIPTION
While editing the conf.py file, clean up line lengths as well, and shut pyright up about the sphinxcontrib.spelling import.

## Related issue number

Fixes #295

