### PR TITLE
Ignore depr warnings inside pytest on 3.12

### DIFF
--- a/pytest.ci.ini
+++ b/pytest.ci.ini
@@ -1,7 +1,11 @@
 [pytest]
 addopts = --cov=frozenlist --cov-report term-missing:skip-covered -v -rxXs
-filterwarnings = error
 junit_suite_name = frozenlist_test_suite
 norecursedirs = dist docs build .tox .eggs
 minversion = 3.8.2
 testpaths = tests/
+filterwarnings =
+    error
+    # https://github.com/pytest-dev/pytest/issues/10977 and https://github.com/pytest-dev/pytest/pull/10894
+    ignore:ast\.(Num|NameConstant|Str) is deprecated and will be removed in Python 3\.14; use ast\.Constant instead:DeprecationWarning:_pytest
+    ignore:Attribute s is deprecated and will be removed in Python 3\.14; use value instead:DeprecationWarning:_pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,11 @@
 [pytest]
 addopts = --cov=frozenlist
-filterwarnings = error
 junit_suite_name = frozenlist_test_suite
 norecursedirs = dist docs build .tox .eggs
 minversion = 3.8.2
 testpaths = tests/
+filterwarnings =
+    error
+    # https://github.com/pytest-dev/pytest/issues/10977 and https://github.com/pytest-dev/pytest/pull/10894
+    ignore:ast\.(Num|NameConstant|Str) is deprecated and will be removed in Python 3\.14; use ast\.Constant instead:DeprecationWarning:_pytest
+    ignore:Attribute s is deprecated and will be removed in Python 3\.14; use value instead:DeprecationWarning:_pytest


### PR DESCRIPTION
These warnings otherwise would abort the test suite. See pytest-dev/pytest#10977.
