### PR TITLE
Ensure support for Python 3.12 and PyPy 3.8-3.10

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,7 +67,15 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        pyver: ['3.8', '3.9', '3.10', '3.11']
+        pyver:
+          - '3.12'
+          - '3.11'
+          - '3.10'
+          - '3.9'
+          - '3.8'
+          - 'pypy3.10'
+          - 'pypy3.9'
+          - 'pypy3.8'
         no-extensions: ['', 'Y']
         experimental: [false]
         os: [ubuntu, macos, windows]
@@ -76,15 +84,12 @@ jobs:
             no-extensions: 'Y'
           - os: windows
             no-extensions: 'Y'
-        include:
-          - pyver: 3.12-dev
+          - pyver: pypy3.10
             no-extensions: ''
-            experimental: true
-            os: ubuntu
-          - pyver: 3.12-dev
-            no-extensions: 'Y'
-            experimental: true
-            os: ubuntu
+          - pyver: pypy3.9
+            no-extensions: ''
+          - pyver: pypy3.8
+            no-extensions: ''
       fail-fast: false
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 15

--- a/CHANGES/553.feature
+++ b/CHANGES/553.feature
@@ -1,0 +1,1 @@
+Ensure support for Python 3.12 and PyPy 3.8-3.10.

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,9 @@ classifiers =
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
+  Programming Language :: Python :: 3.12
+  Programming Language :: Python :: Implementation :: CPython
+  Programming Language :: Python :: Implementation :: PyPy
   Development Status :: 5 - Production/Stable
   Operating System :: POSIX
   Operating System :: MacOS :: MacOS X

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 
-envlist = check, clean, {py38,py39,py310,py311,py312}-{cython,pure}, report
+envlist = check, clean, py3{12,11,10,9,8}-{cython,pure}, pypy3{10,9,8}-pure, report
 
 [testenv]
 


### PR DESCRIPTION
Hello,

I believe it would be nice to have explicit support for Python 3.12.
So I'd like to propose this PR.

## What do these changes do?

  * enable testing for Python 3.12 and PyPy 3.8-3.10
  * update `classifiers` at `setup.cfg`

## Are there changes in behavior for the user?

No.

## Related issue number

I suppose #541 might be resolved by releasing a new version once this PR is merged.
Since `cibuildwheel` was already updated to `2.16.2`, it will build `wheels` for Python 3.12 as well as for prior versions.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist (sort of)
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
