### PR TITLE
🐛 Fix `__class_getitem__` signature in classes

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,7 +11,7 @@ comment:
   require_changes: true
 
 coverage:
-  range: 99.09..100
+  range: 100..100
   status:
     project:
       default:
@@ -19,7 +19,7 @@ coverage:
       lib:
         paths:
         - frozenlist/
-        target: 97.79%
+        target: 100%
       tests:
         paths:
         - tests/

--- a/CHANGES/567.bugfix.rst
+++ b/CHANGES/567.bugfix.rst
@@ -1,0 +1,1 @@
+571.bugfix.rst

--- a/CHANGES/571.bugfix.rst
+++ b/CHANGES/571.bugfix.rst
@@ -1,0 +1,6 @@
+An incorrect signature of the ``__class_getitem__`` class method
+has been fixed, adding a missing ``class_item`` argument under
+Python 3.8 and older.
+
+This change also improves the code coverage of this method that
+was previously missing -- by :user:`webknjaz`.

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -3,7 +3,7 @@ import sys
 import types
 from collections.abc import MutableSequence
 from functools import total_ordering
-from typing import Type
+from typing import Any, Type
 
 __version__ = "1.4.2.dev0"
 
@@ -22,7 +22,10 @@ class FrozenList(MutableSequence):
     else:
 
         @classmethod
-        def __class_getitem__(cls: Type["FrozenList"]) -> Type["FrozenList"]:
+        def __class_getitem__(
+            cls: Type["FrozenList"],
+            cls_item: Any,
+        ) -> Type["FrozenList"]:
             return cls
 
     def __init__(self, items=None):

--- a/frozenlist/_frozenlist.pyx
+++ b/frozenlist/_frozenlist.pyx
@@ -9,7 +9,7 @@ cdef class FrozenList:
         __class_getitem__ = classmethod(types.GenericAlias)
     else:
         @classmethod
-        def __class_getitem__(cls):
+        def __class_getitem__(cls, cls_item):
             return cls
 
     cdef readonly bint frozen

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -13,6 +13,9 @@ class FrozenListMixin:
 
     SKIP_METHODS = {"__abstractmethods__", "__slots__"}
 
+    def test___class_getitem__(self) -> None:
+        assert self.FrozenList[str] is not None
+
     def test_subclass(self) -> None:
         assert issubclass(self.FrozenList, MutableSequence)
 


### PR DESCRIPTION
This patch also increases the coverage level expectations in the Codecov config and adds a test that hits the line with the missing coverage.

Fixes #567