### PR TITLE
Fix misleading URLs in the documentation

### DIFF
--- a/CHANGES/573.doc.rst
+++ b/CHANGES/573.doc.rst
@@ -1,0 +1,2 @@
+Rendered issue, PR, and commit links now lead to
+``frozenslist``'s repo instead of ``yarl``'s repo.

--- a/CHANGES/573.packaging.rst
+++ b/CHANGES/573.packaging.rst
@@ -1,0 +1,2 @@
+A name of a temporary building directory now reflects
+that it's related to ``frozenslist``, not ``yarl``.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -324,4 +324,3 @@ WSMsgType
 wss
 www
 xxx
-yarl

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -196,7 +196,7 @@ def patched_dist_get_long_description():
 
 @contextmanager
 def _in_temporary_directory(src_dir: Path) -> t.Iterator[None]:
-    with TemporaryDirectory(prefix='.tmp-yarl-pep517-') as tmp_dir:
+    with TemporaryDirectory(prefix='.tmp-frozenlist-pep517-') as tmp_dir:
         with chdir_cm(tmp_dir):
             tmp_src_dir = Path(tmp_dir) / 'src'
             copytree(src_dir, tmp_src_dir, symlinks=True)

--- a/packaging/pep517_backend/_transformers.py
+++ b/packaging/pep517_backend/_transformers.py
@@ -47,7 +47,7 @@ def sanitize_rst_roles(rst_source_text: str) -> str:
     """
     issue_substitution_pattern = (
         r"`#\g<issue_number> "
-        r"<https://github.com/aio-libs/yarl/issues/\g<issue_number>>`__"
+        r"<https://github.com/aio-libs/frozenlist/issues/\g<issue_number>>`__"
     )
 
     pr_role_regex = r"""(?x)
@@ -55,7 +55,7 @@ def sanitize_rst_roles(rst_source_text: str) -> str:
     """
     pr_substitution_pattern = (
         r"`PR #\g<pr_number> "
-        r"<https://github.com/aio-libs/yarl/pull/\g<pr_number>>`__"
+        r"<https://github.com/aio-libs/frozenlist/pull/\g<pr_number>>`__"
     )
 
     commit_role_regex = r"""(?x)
@@ -63,7 +63,7 @@ def sanitize_rst_roles(rst_source_text: str) -> str:
     """
     commit_substitution_pattern = (
         r"`\g<commit_sha> "
-        r"<https://github.com/aio-libs/yarl/commit/\g<commit_sha>>`__"
+        r"<https://github.com/aio-libs/frozenlist/commit/\g<commit_sha>>`__"
     )
 
     gh_role_regex = r"""(?x)


### PR DESCRIPTION
Hello @webknjaz,

I hope you can help to fix this.

## What do these changes do?

Due to an issue with the configuration, links in the documentation [currently point](https://pypi.org/project/frozenlist/1.4.1/#packaging-updates-and-notes-for-downstreams) to `yarl`'s repo instead of `frozenslist`'s repo. To fix that, `yarl` substrings must be replaced with `frozenlist`.

## Are there changes in behavior for the user?

Links to issues/PRs/commits will be fixed.

## Related issue number

PR that introduces an issue:
  * #560

## Checklist

- [x] I think the code is well written
- [x] Add a new news fragment into the `CHANGES` folder