### PR TITLE
Fix the Towncrier philosophy link

### DIFF
--- a/CHANGES/574.doc.rst
+++ b/CHANGES/574.doc.rst
@@ -1,0 +1,2 @@
+On the :doc:`Contributing docs <contributing/guidelines>` page,
+a link to the ``Towncrier philosophy`` has been fixed.

--- a/CHANGES/README.rst
+++ b/CHANGES/README.rst
@@ -106,4 +106,4 @@ File :file:`CHANGES/553.feature.rst`:
    (``tool.towncrier.type``).
 
 .. _Towncrier philosophy:
-   https://towncrier.readthedocs.io/en/actual-freaking-docs/#philosophy
+   https://towncrier.readthedocs.io/en/stable/#philosophy


### PR DESCRIPTION
## What do these changes do?

These changes fix a broken link to `towncrier`'s philosophy.

## Are there changes in behavior for the user?

Link from [Contributing docs](https://frozenlist.aio-libs.org/en/latest/contributing/guidelines/#adding-change-notes-with-your-prs) to `towncrier`'s philosophy will be fixed.

## Related issue number

`N/A`

## Checklist

- [x] I think the code is well written
- [x] Add a new news fragment into the `CHANGES` folder
