### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,62 @@ Changelog
 
 .. towncrier release notes start
 
+1.5.0 (2024-10-22)
+==================
+
+Bug fixes
+---------
+
+- An incorrect signature of the ``__class_getitem__`` class method
+  has been fixed, adding a missing ``class_item`` argument under
+  Python 3.8 and older.
+
+  This change also improves the code coverage of this method that
+  was previously missing -- by :user:`webknjaz`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`567`, :issue:`571`.
+
+
+Improved documentation
+----------------------
+
+- Rendered issue, PR, and commit links now lead to
+  ``frozenlist``'s repo instead of ``yarl``'s repo.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`573`.
+
+- On the :doc:`Contributing docs <contributing/guidelines>` page,
+  a link to the ``Towncrier philosophy`` has been fixed.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`574`.
+
+
+Packaging updates and notes for downstreams
+-------------------------------------------
+
+- A name of a temporary building directory now reflects
+  that it's related to ``frozenlist``, not ``yarl``.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`573`.
+
+- Declared Python 3.13 supported officially in the distribution package metadata.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`595`.
+
+
+----
+
+
 1.4.1 (2023-12-15)
 ==================
 

--- a/CHANGES/567.bugfix.rst
+++ b/CHANGES/567.bugfix.rst
@@ -1,1 +1,0 @@
-571.bugfix.rst

--- a/CHANGES/571.bugfix.rst
+++ b/CHANGES/571.bugfix.rst
@@ -1,6 +1,0 @@
-An incorrect signature of the ``__class_getitem__`` class method
-has been fixed, adding a missing ``class_item`` argument under
-Python 3.8 and older.
-
-This change also improves the code coverage of this method that
-was previously missing -- by :user:`webknjaz`.

--- a/CHANGES/573.doc.rst
+++ b/CHANGES/573.doc.rst
@@ -1,2 +1,0 @@
-Rendered issue, PR, and commit links now lead to
-``frozenslist``'s repo instead of ``yarl``'s repo.

--- a/CHANGES/573.packaging.rst
+++ b/CHANGES/573.packaging.rst
@@ -1,2 +1,0 @@
-A name of a temporary building directory now reflects
-that it's related to ``frozenslist``, not ``yarl``.

--- a/CHANGES/574.doc.rst
+++ b/CHANGES/574.doc.rst
@@ -1,2 +1,0 @@
-On the :doc:`Contributing docs <contributing/guidelines>` page,
-a link to the ``Towncrier philosophy`` has been fixed.

--- a/CHANGES/595.packaging.rst
+++ b/CHANGES/595.packaging.rst
@@ -1,1 +1,0 @@
-Declared Python 3.13 supported officially in the distribution package metadata.

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -5,7 +5,7 @@ from collections.abc import MutableSequence
 from functools import total_ordering
 from typing import Any, Type
 
-__version__ = "1.4.2.dev0"
+__version__ = "1.5.0"
 
 __all__ = ("FrozenList", "PyFrozenList")  # type: Tuple[str, ...]
 


### PR DESCRIPTION
closes #608

TODO
- [x] fix typos in changelog
- [x] review changes some more, post image
- [x] rebase this
- [x] verify cleanup merges that might make the release fail auto merged

<img width="585" alt="Screenshot 2024-10-22 at 6 09 45 PM" src="https://github.com/user-attachments/assets/e97a413c-8a96-4f06-9e88-1ee4ec6d3c01">
