### PR TITLE
Implement support for the free-threaded build of CPython 3.13

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -169,6 +169,7 @@ jobs:
     strategy:
       matrix:
         pyver:
+        - 3.13t
         - 3.13
         - 3.12
         - 3.11
@@ -221,7 +222,7 @@ jobs:
 
     - name: Setup Python ${{ matrix.pyver }}
       id: python-install
-      uses: actions/setup-python@v5
+      uses: quansight-labs/setup-python@v5
       with:
         python-version: ${{ matrix.pyver }}
         allow-prereleases: true

--- a/frozenlist/_frozenlist.pyx
+++ b/frozenlist/_frozenlist.pyx
@@ -1,3 +1,5 @@
+# cython: freethreading_compatible=True
+
 import sys
 import types
 from collections.abc import MutableSequence

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -374,7 +374,8 @@ def get_requires_for_build_wheel(
         )
 
     c_ext_build_deps = [] if is_pure_python_build else [
-        'Cython ~= 3.0.0; python_version >= "3.12"',
+        'Cython == 3.1.0a1; python_version >= "3.13"',
+        'Cython ~= 3.0.0; python_version == "3.12"',
         'Cython; python_version < "3.12"',
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ linetrace = "True"  # Implies `profile=True`
 #error_on_uninitialized = "True"
 
 [tool.cibuildwheel]
+enable = ["cpython-freethreading"]
 build-frontend = "build"
 before-test = [
   # NOTE: Attempt to have pip pre-compile PyYAML wheel with our build

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,7 +1,8 @@
 -r towncrier.txt
 build==1.0.3
 coverage==7.6.1
-cython==3.0.6
+cython==3.0.6; python_version < '3.13'
+cython==3.1.0a1; python_version >= '3.13'
 pre-commit==3.5.0
 pytest==7.4.3
 pytest-cov==4.1.0


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

- Change Cython dependency to 3.1.0a1 for CPython 3.13 to support free-threading
- Test the free-threaded build on CI
- *IMPORTANT*: There's still some thread-safety issues regarding the `frozen` attribute of `FrozenList`, which I would like to wait for cython/cython#6577 for. In practice that won't be hit too often, so I'm opening this PR already.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No.
<!-- Outline any notable behaviour for the end users. -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modifications, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep the list in alphabetical order, the file is sorted by name.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
