### PR TITLE
🧪 Drop `setup-python` cache path from the test job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -221,7 +221,6 @@ jobs:
         python-version: ${{ matrix.pyver }}
         allow-prereleases: true
         cache: pip
-        cache-dependency-path: requirements/*.txt
     - name: Install dependencies
       uses: py-actions/py-dependency-install@v4
       with:


### PR DESCRIPTION
SSIA. xref #622. Experiment for https://github.com/actions/setup-python/issues/1034.