### PR TITLE
Fix towncrier head_line missing the leading v

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -472,7 +472,7 @@ jobs:
         version_file: ${{ env.PROJECT_NAME }}/__init__.py
         github_token: ${{ secrets.GITHUB_TOKEN }}
         head_line: >-
-          {version}\n=+\n\n\*\({date}\)\*\n
+          v{version}\n=+\n\n\*\({date}\)\*\n
         fix_issue_regex: >-
           :issue:`(\d+)`
         fix_issue_repl: >-


### PR DESCRIPTION
1.6.0 failed because the head_line could not be found https://github.com/aio-libs/frozenlist/actions/runs/14525098275/job/40755685776
