### PR TITLE
Update the PR template to be consistent with CHANGES/README.rst

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,12 +21,14 @@
   * The format is &lt;Name&gt; &lt;Surname&gt;.
   * Please keep the list in alphabetical order, the file is sorted by name.
 - [ ] Add a new news fragment into the `CHANGES` folder
-  * name it `<issue_id>.<type>` for example (588.bugfix)
+  * name it `<issue_id>.<category>` for example (588.bugfix)
   * if you don't have an `issue_id` change it to the pr id after creating the pr
-  * ensure type is one of the following:
-    * `.feature`: Signifying a new feature.
+  * ensure category is one of the following:
     * `.bugfix`: Signifying a bug fix.
+    * `.feature`: Signifying a new feature.
+    * `.breaking`: Signifying a breaking change or removal of something public.
     * `.doc`: Signifying a documentation improvement.
-    * `.removal`: Signifying a deprecation or removal of public API.
-    * `.misc`: A ticket has been closed, but it is not of interest to users.
+    * `.packaging`: Signifying a packaging or tooling change that may be relevant to downstreams.
+    * `.contrib`: Signifying an improvement to the contributor/development experience.
+    * `.misc`: Anything that does not fit the above; usually, something not of interest to users.
   * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Updates the part of the PR template pertaining to news fragments to more closely reflect `CHANGES/README.rst`. Based on discussion in https://github.com/aio-libs/frozenlist/pull/649.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No; contributors will see a more accurate list of change categories when opening PR’s.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
N/A

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist **N/A**
- [ ] Documentation reflects the changes **N/A**
- [ ] If you provide code modifications, please add yourself to `CONTRIBUTORS.txt` **N/A**
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep the list in alphabetical order, the file is sorted by name.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
