### PR TITLE
Remove installing libenchant-2-dev from the lint workflow

### DIFF
--- a/.github/workflows/reusable-linters.yml
+++ b/.github/workflows/reusable-linters.yml
@@ -78,7 +78,6 @@ jobs:
         fail_ci_if_error: true
     - name: Install spell checker
       run: |
-        sudo apt install libenchant-2-dev
         pip install -r requirements/doc.txt
     - name: Run docs spelling
       run: |


### PR DESCRIPTION
This is no longer needed as its already available
