### PR TITLE
Only enable line tracing when building with Cython tracing

### DIFF
--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -291,7 +291,7 @@ def maybe_prebuild_c_extensions(
     with build_dir_ctx:
         config = _get_local_cython_config()
 
-        cythonize_args = _make_cythonize_cli_args_from_config(config)
+        cythonize_args = _make_cythonize_cli_args_from_config(config, cython_line_tracing_requested)
         with _patched_cython_env(config['env'], cython_line_tracing_requested):
             _cythonize_cli_cmd(cythonize_args)
         with patched_distutils_cmd_install():

--- a/packaging/pep517_backend/_cython_configuration.py
+++ b/packaging/pep517_backend/_cython_configuration.py
@@ -17,8 +17,18 @@ from ._transformers import get_cli_kwargs_from_config, get_enabled_cli_flags_fro
 class Config(TypedDict):
     env: dict[str, str]
     flags: dict[str, bool]
-    kwargs: dict[str, str]
+    kwargs: dict[str, str | dict[str, str]]
     src: list[str]
+
+
+def _configure_cython_line_tracing(config_kwargs: dict[str, str | dict[str, str]], cython_line_tracing_requested: bool) -> None:
+    """Configure Cython line tracing directives if requested."""
+    # If line tracing is requested, add it to the directives
+    if cython_line_tracing_requested:
+        directives = config_kwargs.setdefault('directives', {})
+        assert isinstance(directives, dict)  # Type narrowing for mypy
+        directives['linetrace'] = 'True'
+        directives['profile'] = 'True'
 
 
 def get_local_cython_config() -> Config:
@@ -78,11 +88,15 @@ def get_local_cython_config() -> Config:
     return config_mapping['tool']['local']['cythonize']  # type: ignore[no-any-return]
 
 
-def make_cythonize_cli_args_from_config(config: Config) -> list[str]:
+def make_cythonize_cli_args_from_config(config: Config, cython_line_tracing_requested: bool = False) -> list[str]:
     py_ver_arg = f'-{_python_version_tuple.major!s}'
 
     cli_flags = get_enabled_cli_flags_from_config(config['flags'])
-    cli_kwargs = get_cli_kwargs_from_config(config['kwargs'])
+
+    config_kwargs = config['kwargs']
+    _configure_cython_line_tracing(config_kwargs, cython_line_tracing_requested)
+
+    cli_kwargs = get_cli_kwargs_from_config(config_kwargs)
 
     return cli_flags + [py_ver_arg] + cli_kwargs + ['--'] + config['src']
 

--- a/packaging/pep517_backend/_transformers.py
+++ b/packaging/pep517_backend/_transformers.py
@@ -16,7 +16,9 @@ def _emit_opt_pairs(opt_pair: Tuple[str, Union[str, Dict[str, str]]]) -> Iterato
     yield from ("=".join(map(str, (flag_opt,) + pair)) for pair in sub_pairs)
 
 
-def get_cli_kwargs_from_config(kwargs_map: Mapping[str, str]) -> List[str]:
+def get_cli_kwargs_from_config(
+    kwargs_map: Mapping[str, Union[str, Dict[str, str]]],
+) -> List[str]:
     """Make a list of options with values from config."""
     return list(chain.from_iterable(map(_emit_opt_pairs, kwargs_map.items())))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ keep-going = false
 # https://cython.rtfd.io/en/latest/src/userguide/source_files_and_compilation.html#compiler-directives
 embedsignature = "True"
 emit_code_comments = "True"
-linetrace = "True"  # Implies `profile=True`
 
 [tool.local.cythonize.kwargs.compile-time-env]
 # This section can contain compile time env vars


### PR DESCRIPTION
## What do these changes do?

Only enable line tracing when building with Cython tracing

This PR modifies the build backend to dynamically enable Cython line tracing only when explicitly requested via the `with-cython-tracing=true` config setting. Previously, having `linetrace = "True"` in pyproject.toml was causing build issues for users (https://github.com/aio-libs/frozenlist/issues/658) and makes our production wheels almost half as fast.

Now, line tracing is opt-in:
- Regular builds: `pip install .` (no line tracing)
- Tracing builds: `pip install . --config-setting=with-cython-tracing=true` (enables line tracing)

When tracing is requested, the build backend automatically adds the `linetrace=True` and `profile=True` Cython directives and sets the appropriate C compiler flags.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

- Regular users will no longer encounter build issues related to line tracing being enabled by default
- Developers who need line tracing must now explicitly enable it using `--config-setting=with-cython-tracing=true`
- The `YARL_CYTHON_TRACING` environment variable can also be used as an alternative to the config setting

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes