### PR TITLE
Implement deepcopy support

### DIFF
--- a/CHANGES/659.feature.rst
+++ b/CHANGES/659.feature.rst
@@ -1,0 +1,1 @@
+Add deepcopy support to FrozenList -- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -79,6 +79,7 @@ cythonized
 Cythonize
 de
 deduplicate
+deepcopy
 # de-facto:
 deprecations
 DER

--- a/frozenlist/_frozenlist.pyx
+++ b/frozenlist/_frozenlist.pyx
@@ -4,6 +4,7 @@
 from cpython.bool cimport PyBool_FromLong
 from libcpp.atomic cimport atomic
 
+import copy
 import types
 from collections.abc import MutableSequence
 
@@ -121,6 +122,27 @@ cdef class FrozenList:
             return hash(tuple(self._items))
         else:
             raise RuntimeError("Cannot hash unfrozen list.")
+
+    def __deepcopy__(self, memo):
+        cdef FrozenList new_list
+        obj_id = id(self)
+
+        # Return existing copy if already processed (circular reference)
+        if obj_id in memo:
+            return memo[obj_id]
+
+        # Create new instance and register immediately
+        new_list = self.__class__([])
+        memo[obj_id] = new_list
+
+        # Deep copy items
+        new_list._items[:] = [copy.deepcopy(item, memo) for item in self._items]
+
+        # Preserve frozen state
+        if self._frozen.load():
+            new_list.freeze()
+
+        return new_list
 
 
 MutableSequence.register(FrozenList)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Implements deepcopy support for FrozenList by adding a `__deepcopy__` method. This allows FrozenList objects to be deep copied using Python's `copy.deepcopy()` function, which was previously failing with a TypeError.

## Are there changes in behavior for the user?

Users can now use `copy.deepcopy()` on FrozenList objects without errors. The deepcopy operation:
- Creates a complete copy of the FrozenList and all its contents
- Preserves the frozen state of the original list
- Correctly handles circular references and nested structures
- Maintains shared references within the copied structure

## Related issue number

Closes #659

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modifications, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep the list in alphabetical order, the file is sorted by name.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."