### PR TITLE
Make sure that frozenlists are pickle-able

### DIFF
--- a/CHANGES/718.bugfix.rst
+++ b/CHANGES/718.bugfix.rst
@@ -1,2 +1,5 @@
-Fix bug where FrozenList could not be pickled/unpickled.
+Fixed a bug where FrozenList could not be pickled/unpickled.
+
+Pickling is a requirement for FrozenList to be able to be passed to multiprocessing Processes. Without this
+fix, users receive a TypeError upon attempting to pickle a FrozenList.
 -- by :user:`csm10495`.

--- a/CHANGES/718.bugfix.rst
+++ b/CHANGES/718.bugfix.rst
@@ -1,5 +1,5 @@
-Fixed a bug where FrozenList could not be pickled/unpickled.
+Fixed a bug where :class:`~frozenlist.FrozenList` could not be pickled/unpickled.
 
-Pickling is a requirement for FrozenList to be able to be passed to multiprocessing Processes. Without this
-fix, users receive a TypeError upon attempting to pickle a FrozenList.
+Pickling is a requirement for :class:`~frozenlist.FrozenList` to be able to be passed to :class:`multiprocessing.Process`\ es. Without this
+fix, users receive a :exc:`TypeError` upon attempting to pickle a :class:`~frozenlist.FrozenList`.
 -- by :user:`csm10495`.

--- a/CHANGES/718.bugfix.rst
+++ b/CHANGES/718.bugfix.rst
@@ -1,0 +1,2 @@
+Fix bug where FrozenList could not be pickled/unpickled.
+-- by :user:`csm10495`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,6 +1,7 @@
 - Contributors -
 ----------------
 Andrew Svetlov
+Charles Machalow
 Edgar Ramírez-Mondragón
 Marcin Konowalczyk
 Martijn Pieters

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -302,6 +302,7 @@ unicode
 unittest
 Unittest
 unix
+unpickled
 unsets
 unstripped
 upstr

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -3,7 +3,6 @@ import os
 import types
 from collections.abc import MutableSequence
 from functools import total_ordering
-from typing import Any
 
 __version__ = "1.8.1.dev0"
 
@@ -105,7 +104,7 @@ class FrozenList(MutableSequence):
         )
 
 
-def _reconstruct_pyfrozenlist(items: list[Any], frozen: bool) -> "PyFrozenList":
+def _reconstruct_pyfrozenlist(items: list[object], frozen: bool) -> "PyFrozenList":
     """Helper function to reconstruct the pure Python FrozenList during unpickling.
     This function is needed since otherwise the class renaming confuses pickle."""
     fl = PyFrozenList(items)

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -77,10 +77,6 @@ class FrozenList(MutableSequence):
     def __deepcopy__(self, memo: dict[int, object]):
         obj_id = id(self)
 
-        # Return existing copy if already processed (circular reference)
-        if obj_id in memo:
-            return memo[obj_id]
-
         # Create new instance and register immediately
         new_list = self.__class__([])
         memo[obj_id] = new_list

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -10,7 +10,6 @@ __version__ = "1.8.1.dev0"
 __all__ = (
     "FrozenList",
     "PyFrozenList",
-    "_reconstruct_pyfrozenlist",
 )  # type: Tuple[str, ...]
 
 

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -78,7 +78,7 @@ class FrozenList(MutableSequence):
         else:
             raise RuntimeError("Cannot hash unfrozen list.")
 
-    def __deepcopy__(self, memo: dict[int, Any]):
+    def __deepcopy__(self, memo: dict[int, object]):
         obj_id = id(self)
 
         # Return existing copy if already processed (circular reference)

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -6,10 +6,7 @@ from functools import total_ordering
 
 __version__ = "1.8.1.dev0"
 
-__all__ = (
-    "FrozenList",
-    "PyFrozenList",
-)  # type: Tuple[str, ...]
+__all__ = ("FrozenList", "PyFrozenList")  # type: Tuple[str, ...]
 
 
 NO_EXTENSIONS = bool(os.environ.get("FROZENLIST_NO_EXTENSIONS"))  # type: bool
@@ -104,17 +101,17 @@ class FrozenList(MutableSequence):
         )
 
 
-def _reconstruct_pyfrozenlist(items: list[object], frozen: bool) -> "PyFrozenList":
+# Store a reference to the pure Python implementation before it's potentially replaced
+PyFrozenList = FrozenList
+
+
+def _reconstruct_pyfrozenlist(items: list[object], frozen: bool) -> PyFrozenList:
     """Helper function to reconstruct the pure Python FrozenList during unpickling.
     This function is needed since otherwise the class renaming confuses pickle."""
     fl = PyFrozenList(items)
     if frozen:
         fl.freeze()
     return fl
-
-
-# Store a reference to the pure Python implementation before it's potentially replaced
-PyFrozenList = FrozenList
 
 
 if not NO_EXTENSIONS:

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -106,7 +106,7 @@ class FrozenList(MutableSequence):
         )
 
 
-def _reconstruct_pyfrozenlist(items, frozen):
+def _reconstruct_pyfrozenlist(items: list[Any], frozen: bool) -> "PyFrozenList":
     """Helper function to reconstruct the pure Python FrozenList during unpickling.
     This function is needed since otherwise the class renaming confuses pickle."""
     fl = PyFrozenList(items)

--- a/frozenlist/_frozenlist.pyx
+++ b/frozenlist/_frozenlist.pyx
@@ -144,5 +144,15 @@ cdef class FrozenList:
 
         return new_list
 
+    def __reduce__(self):
+        return (
+            self.__class__,
+            (self._items,),
+            {"_frozen": self._frozen.load()},
+        )
+
+    def __setstate__(self, state):
+        self._frozen.store(state["_frozen"])
+
 
 MutableSequence.register(FrozenList)

--- a/frozenlist/_frozenlist.pyx
+++ b/frozenlist/_frozenlist.pyx
@@ -127,10 +127,6 @@ cdef class FrozenList:
         cdef FrozenList new_list
         obj_id = id(self)
 
-        # Return existing copy if already processed (circular reference)
-        if obj_id in memo:
-            return memo[obj_id]
-
         # Create new instance and register immediately
         new_list = self.__class__([])
         memo[obj_id] = new_list

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -387,7 +387,7 @@ class FrozenListMixin:
         assert len(copied[1]) == 3  # Should see the change
         assert len(shared) == 2  # Original unchanged
 
-    @pytest.mark.parametrize("freeze", [True, False])
+    @pytest.mark.parametrize("freeze", [True, False], ids=["frozen", "not frozen"])
     def test_picklability(self, freeze: bool) -> None:
         # Test that the list can be pickled and unpickled successfully
         orig = self.FrozenList([1, 2, 3])

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -274,6 +274,20 @@ class FrozenListMixin:
         with pytest.raises(RuntimeError):
             copied.append(4)
 
+    def test_deepcopy_frozen_circular(self) -> None:
+        orig = self.FrozenList([1, 2])
+        orig.append(orig)  # Create circular reference
+        orig.freeze()
+        copied = deepcopy(orig)
+        assert copied[0] == 1
+        assert copied[1] == 2
+        assert len(copied[2]) == 3
+        assert copied[2][0] == 1
+        assert copied[2][1] == 2
+        assert len(copied[2][2]) == 3
+        # ... and so on. Testing equality when a structure includes itself is tough.
+        assert orig.frozen
+
     def test_deepcopy_nested(self) -> None:
         inner = self.FrozenList([1, 2])
         orig = self.FrozenList([inner, 3])

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -1,6 +1,7 @@
 # FIXME:
 # mypy: disable-error-code="misc"
 
+import pickle
 from collections.abc import MutableSequence
 from copy import deepcopy
 
@@ -371,6 +372,23 @@ class FrozenListMixin:
         assert len(copied[0]) == 3
         assert len(copied[1]) == 3  # Should see the change
         assert len(shared) == 2  # Original unchanged
+
+    @pytest.mark.parametrize("freeze", [True, False])
+    def test_picklability(self, freeze: bool) -> None:
+        # Test that the list can be pickled and unpickled successfully
+        orig = self.FrozenList([1, 2, 3])
+        if freeze:
+            orig.freeze()
+
+        assert orig.frozen == freeze
+
+        pickled = pickle.dumps(orig)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == orig
+        assert unpickled is not orig
+        assert list(unpickled) == list(orig)
+
+        assert unpickled.frozen == freeze
 
 
 class TestFrozenList(FrozenListMixin):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fixes bug where frozenlists can't be pickled.

## Are there changes in behavior for the user?

Not directly. Though this fixes a behavior change introduced after 1.6.0

## Related issue number

#683

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modifications, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep the list in alphabetical order, the file is sorted by name.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<category>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure category is one of the following:
    * `.bugfix`: Signifying a bug fix.
    * `.feature`: Signifying a new feature.
    * `.breaking`: Signifying a breaking change or removal of something public.
    * `.doc`: Signifying a documentation improvement.
    * `.packaging`: Signifying a packaging or tooling change that may be relevant to downstreams.
    * `.contrib`: Signifying an improvement to the contributor/development experience.
    * `.misc`: Anything that does not fit the above; usually, something not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
