### PR TITLE
ci: add riscv64 wheels

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -431,6 +431,7 @@ jobs:
         - ppc64le
         - s390x
         - armv7l
+        - riscv64
         tag:
         - ''
         - musllinux

--- a/CHANGES/741.packaging.rst
+++ b/CHANGES/741.packaging.rst
@@ -1,0 +1,2 @@
+Added support for building and shipping riscv64 wheels
+-- by :user:`justeph` and :user:`gounthar`.

--- a/CHANGES/744.packaging.rst
+++ b/CHANGES/744.packaging.rst
@@ -1,0 +1,1 @@
+741.packaging.rst

--- a/CHANGES/745.packaging.rst
+++ b/CHANGES/745.packaging.rst
@@ -1,0 +1,1 @@
+741.packaging.rst

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -249,6 +249,8 @@ resolvehost
 resolvers
 reusage
 reuseconn
+riscv
+riscv64
 Runit
 runtimes
 sa


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?
Now that cibuildwheel and PyPI support riscv64, we can start building riscv64 wheels.

## Are there changes in behavior for the user?
frozenlist now runs on riscv64 machines :) 

## Related issue number

No issue opened

## Checklist

- [X] I think the code is well written
- [X] Documentation reflects the changes
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<category>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure category is one of the following:
    * `.bugfix`: Signifying a bug fix.
    * `.feature`: Signifying a new feature.
    * `.breaking`: Signifying a breaking change or removal of something public.
    * `.doc`: Signifying a documentation improvement.
    * `.packaging`: Signifying a packaging or tooling change that may be relevant to downstreams.
    * `.contrib`: Signifying an improvement to the contributor/development experience.
    * `.misc`: Anything that does not fit the above; usually, something not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."