### PR TITLE
ci: add riscv64 to wheel build matrix

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -431,6 +431,7 @@ jobs:
         - ppc64le
         - s390x
         - armv7l
+        - riscv64
         tag:
         - ''
         - musllinux

--- a/CHANGES/745.packaging.rst
+++ b/CHANGES/745.packaging.rst
@@ -1,0 +1,1 @@
+Added riscv64 to the Linux wheel build matrix -- by :user:`gounthar`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add `riscv64` to the Linux wheel build matrix so that `linux_riscv64` wheels are built and published to PyPI alongside existing architectures.

Changes:
- Add `riscv64` entry to the `qemu` matrix in `ci-cd.yml`

## Are there changes in behavior for the user?

riscv64 Linux users will be able to `pip install frozenlist` without building from source.

## Related issue number

Fixes #744

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modifications, please add yourself to `CONTRIBUTORS.txt`
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `745.feature`
  * ensure category is `.feature`
  * "Add riscv64 to the Linux wheel build matrix."