### PR TITLE
Add '__annotations_cache__' to SKIP_METHODS

### DIFF
--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -14,6 +14,7 @@ class FrozenListMixin:
 
     SKIP_METHODS = {
         "__abstractmethods__",
+        "__annotate_func__",
         "__annotations_cache__",
         "__slots__",
         "__static_attributes__",

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -14,6 +14,7 @@ class FrozenListMixin:
 
     SKIP_METHODS = {
         "__abstractmethods__",
+        "__annotations_cache__",
         "__slots__",
         "__static_attributes__",
         "__firstlineno__",


### PR DESCRIPTION
This seems to have turned up in a patch release of Python 3.14. I don't see any mention of `__annotations__` or similar anywhere, so my assumption is that we should just ignore this..