### PR TITLE
Migrate code formatting from black + isort to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,15 +14,23 @@ repos:
   - id: yesqa
     additional_dependencies:
     - wemake-python-styleguide
-- repo: https://github.com/PyCQA/isort
-  rev: '8.0.1'
+- repo: https://github.com/astral-sh/ruff-pre-commit.git
+  rev: v0.15.13
   hooks:
-  - id: isort
-- repo: https://github.com/psf/black-pre-commit-mirror
-  rev: '26.3.1'
-  hooks:
-  - id: black
-    language_version: python3  # Should be a command that runs python3
+  - id: ruff-check
+    name: ruff check | frozenlist & tests
+    # Uses the [tool.ruff] config in pyproject.toml. Enforces the ``I``
+    # rule (import sorting, replacing the standalone isort hook). Runs
+    # before ruff-format because --fix is used.
+    args:
+    # Ref: https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    - --exit-non-zero-on-fix
+    - --fix
+    - --show-fixes
+  - id: ruff-format
+    name: ruff format | frozenlist & tests
+    # Replaces the standalone black hook. Defaults to a black-compatible
+    # 88-column style; see [tool.ruff] in pyproject.toml.
 
 - repo: https://github.com/python-jsonschema/check-jsonschema.git
   rev: 0.37.1

--- a/CHANGES/762.contrib.rst
+++ b/CHANGES/762.contrib.rst
@@ -1,0 +1,7 @@
+Migrated from standalone ``black`` and ``isort`` pre-commit
+hooks to ``ruff format`` and the ruff ``I`` lint rule, sharing
+a new ``[tool.ruff]`` config in ``pyproject.toml``. The
+``ruff-check`` hook runs with ``--fix`` so import-order fixes
+apply on commit, and the orphan ``[isort]`` block in
+``setup.cfg`` was removed
+-- by :user:`bdraco`.

--- a/packaging/pep517_backend/_compat.py
+++ b/packaging/pep517_backend/_compat.py
@@ -8,6 +8,7 @@ from typing import Iterator
 
 if sys.version_info >= (3, 11):
     from contextlib import chdir as chdir_cm
+
     from tomllib import loads as load_toml_from_string
 else:
     from tomli import loads as load_toml_from_string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,24 @@ emit_code_comments = "True"
 #error_on_unknown_names = "True"
 #error_on_uninitialized = "True"
 
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+# Keep this list small and intentional; the rest of the project still
+# relies on flake8 for general style. The rules below are ones we want
+# to enforce repo-wide as a baseline.
+select = [
+  # Import sorting. Replaces the dedicated isort pre-commit hook so the
+  # formatter (ruff format) and the import sorter (ruff check --select I)
+  # come from the same tool and rev.
+  "I",
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["frozenlist"]
+known-third-party = ["pytest"]
+
 [tool.cibuildwheel]
 enable = ["cpython-freethreading"]
 build-frontend = "build"

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,13 +11,3 @@ per-file-ignores =
 
   # F401   imported but unused
   packaging/pep517_backend/hooks.py: F401
-
-[isort]
-profile=black
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-
-known_third_party=pytest
-known_first_party=frozenlist


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Drop the standalone `black` and `isort` pre-commit hooks and use ruff for both formatting and import sorting. Adds a minimal `[tool.ruff]` config in `pyproject.toml` that selects only the `I` rule (import sorting, replacing isort), wires a `ruff-check` hook (with `--fix --exit-non-zero-on-fix --show-fixes`, so import-order fixes apply on commit) and a `ruff-format` hook, and removes the orphan `[isort]` block from `setup.cfg`.

`ruff format` produced no diffs against the existing tree. `ruff check --select I --fix` made one small change: a blank line between two stdlib imports inside a `sys.version_info >= (3, 11)` block in `packaging/pep517_backend/_compat.py`.

## Are there changes in behavior for the user?

No, contributor tooling only.

## Related issue number

N/A; ported from [aio-libs/yarl#1698](https://github.com/aio-libs/yarl/pull/1698).

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist: N/A (tooling-only change; verified by running the full `pre-commit` suite and importing the package)
- [x] Documentation reflects the changes: N/A (no user-visible API change)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`: N/A (no such file in this repo)
- [x] Add a new news fragment into the `CHANGES/` folder (`CHANGES/762.contrib.rst`)

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

Verified:

```
$ ruff check frozenlist/ tests/ packaging/ docs/conf.py
All checks passed!
$ ruff format --check frozenlist/ tests/ packaging/ docs/conf.py
13 files already formatted
$ pre-commit run --all-files
All hooks passed (including mypy).
$ python -c "import frozenlist; fl = frozenlist.FrozenList([1,2,3]); fl.freeze(); print(fl)"
<FrozenList(frozen=True, [1, 2, 3])>
```

</details>