### PR TITLE
Pin coverage core to ctrace for Python 3.14 compatibility

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -19,6 +19,9 @@ show_missing = true
 
 [run]
 branch = true
+# Cython.Coverage plugin is not supported on sysmon core which is default on
+# Python 3.14+ so always use ctrace core
+core = ctrace
 cover_pylib = false
 # https://coverage.rtfd.io/en/latest/contexts.html#dynamic-contexts
 # dynamic_context = test_function  # conflicts with `pytest-cov` if set here

--- a/.coveragerc
+++ b/.coveragerc
@@ -19,9 +19,6 @@ show_missing = true
 
 [run]
 branch = true
-# Cython.Coverage plugin is not supported on sysmon core which is default on
-# Python 3.14+ so always use ctrace core
-core = ctrace
 cover_pylib = false
 # https://coverage.rtfd.io/en/latest/contexts.html#dynamic-contexts
 # dynamic_context = test_function  # conflicts with `pytest-cov` if set here

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,12 +28,6 @@ concurrency:
 env:
   COLOR: >-  # Supposedly, pytest or coveragepy use this
     yes
-  # The Cython.Coverage plugin uses file tracers which the SysMonitor
-  # core (default on Python 3.14+ with coverage.py >= 7.7) does not
-  # support, so pin the coverage core to ``ctrace``. The env var has
-  # been honored since coverage.py 7.4 and is a no-op on older
-  # versions whose default core is already ``ctrace``.
-  COVERAGE_CORE: ctrace
   FORCE_COLOR: 1  # Request colored output from CLI tools supporting it
   MYPY_FORCE_COLOR: 1  # MyPy's color enforcement
   PIP_DISABLE_PIP_VERSION_CHECK: 1
@@ -247,6 +241,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     continue-on-error: ${{ matrix.experimental }}
+    env:
+      # Pin the coverage.py core to ``ctrace`` on CPython. On Python
+      # 3.14+ with coverage.py >= 7.7, the default is the ``sysmon``
+      # core, which does not support plugin file tracers and breaks
+      # the ``Cython.Coverage`` plugin. PyPy ships without CTracer
+      # and would abort with "COVERAGE_CORE is 'ctrace' but can't
+      # import CTracer!", so leave the value empty there.
+      COVERAGE_CORE: >-
+        ${{ startsWith(matrix.pyver, 'pypy') && '' || 'ctrace' }}
     steps:
     - name: Retrieve the project source from an sdist inside the GHA artifact
       uses: re-actors/checkout-python-sdist@release/v2

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,6 +28,12 @@ concurrency:
 env:
   COLOR: >-  # Supposedly, pytest or coveragepy use this
     yes
+  # The Cython.Coverage plugin uses file tracers which the SysMonitor
+  # core (default on Python 3.14+ with coverage.py >= 7.7) does not
+  # support, so pin the coverage core to ``ctrace``. The env var has
+  # been honored since coverage.py 7.4 and is a no-op on older
+  # versions whose default core is already ``ctrace``.
+  COVERAGE_CORE: ctrace
   FORCE_COLOR: 1  # Request colored output from CLI tools supporting it
   MYPY_FORCE_COLOR: 1  # MyPy's color enforcement
   PIP_DISABLE_PIP_VERSION_CHECK: 1

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -247,9 +247,12 @@ jobs:
       # core, which does not support plugin file tracers and breaks
       # the ``Cython.Coverage`` plugin. PyPy ships without CTracer
       # and would abort with "COVERAGE_CORE is 'ctrace' but can't
-      # import CTracer!", so leave the value empty there.
+      # import CTracer!", so use ``pytrace`` there (its default).
+      # An empty string would be falsy in the GHA expression below
+      # and collapse back to ``ctrace``, so the PyPy branch needs a
+      # real value.
       COVERAGE_CORE: >-
-        ${{ startsWith(matrix.pyver, 'pypy') && '' || 'ctrace' }}
+        ${{ startsWith(matrix.pyver, 'pypy') && 'pytrace' || 'ctrace' }}
     steps:
     - name: Retrieve the project source from an sdist inside the GHA artifact
       uses: re-actors/checkout-python-sdist@release/v2

--- a/CHANGES/763.contrib.rst
+++ b/CHANGES/763.contrib.rst
@@ -1,0 +1,5 @@
+Pinned the coverage core to ``ctrace`` in :file:`.coveragerc`
+so that the ``Cython.Coverage`` plugin keeps working on Python
+3.14, where coverage otherwise defaults to the ``sysmon`` core
+that does not support plugin file tracers
+-- by :user:`bdraco`.

--- a/CHANGES/763.contrib.rst
+++ b/CHANGES/763.contrib.rst
@@ -1,5 +1,6 @@
-Pinned the coverage core to ``ctrace`` in :file:`.coveragerc`
-so that the ``Cython.Coverage`` plugin keeps working on Python
-3.14, where coverage otherwise defaults to the ``sysmon`` core
-that does not support plugin file tracers
+Pinned the coverage.py core to ``ctrace`` via the
+``COVERAGE_CORE`` environment variable in the CI workflow so
+that the ``Cython.Coverage`` plugin keeps working on Python
+3.14, where coverage.py otherwise defaults to the ``sysmon``
+core that does not support plugin file tracers
 -- by :user:`bdraco`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -2,6 +2,7 @@
 ----------------
 Andrew Svetlov
 Edgar Ramírez-Mondragón
+J. Nick Koston
 Marcin Konowalczyk
 Martijn Pieters
 Pau Freixes


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Set ``COVERAGE_CORE=ctrace`` in the CI workflow's global ``env:`` block
so that the ``Cython.Coverage`` plugin keeps working on Python 3.14.

On Python 3.14+ with coverage.py >= 7.7, coverage.py defaults to the
``sysmon`` core, which does not support plugin file tracers such as
``Cython.Coverage.Plugin``. With the default core, coverage emits a
``CoverageWarning`` ("Plugin file tracers (Cython.Coverage.Plugin)
aren't supported with SysMonitor"), and the test suite's
``filterwarnings = error`` setting promotes that warning into a hard
failure, taking out every 3.14 job in the matrix.

The ``COVERAGE_CORE`` env var has been honored since coverage.py 7.4
and is a no-op on versions whose default core is already ``ctrace``,
so it works with the current ``coverage==7.6.1`` pin and any later
bump (#735 brings 7.10.7, more recent dependabot branches go further).

The same fix is in place upstream in ``aio-libs/yarl`` (the equivalent
``core = ctrace`` config option, which requires coverage.py >= 7.7
that yarl is already on).

## Are there changes in behavior for the user?

No. CI-only configuration change for coverage collection.

## Related issue number

Surfaces from the failing 3.14 jobs on #735.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modifications, please add yourself to ``CONTRIBUTORS.txt``
- [x] Add a new news fragment into the ``CHANGES`` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Reproduced the failure locally on Python 3.14.2 with
``coverage==7.10.7`` and ``pytest-cov==7.1.0`` against an editable
install built with ``with-cython-tracing=true``: pytest aborts at
collection with ``coverage.exceptions.CoverageWarning: Plugin file
tracers (Cython.Coverage.Plugin) aren't supported with SysMonitor``.
Running with ``COVERAGE_CORE=ctrace`` clears the warning and the full
suite (110 tests) passes. Also verified the env var is a no-op on
``coverage==7.6.1`` (the suite still passes; the variable is read but
its default core was already ``ctrace`` on that version).

A first iteration of this PR set ``core = ctrace`` in ``.coveragerc``
instead of using the env var. That broke every test job because
coverage.py only learned the ``[run] core`` setting in 7.7 and the
repo still pins 7.6.1, so the config was rejected with
"Unrecognized option [run] core=". The env var approach is portable
across both pins.

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.
</details>