### PR TITLE
Switch cibuildwheel to the uv build frontend

### DIFF
--- a/.github/workflows/reusable-cibuildwheel.yml
+++ b/.github/workflows/reusable-cibuildwheel.yml
@@ -112,6 +112,11 @@ jobs:
       with:
         package-dir: >-  # not necessarily a dir, we pass an acceptable sdist
           dist/${{ inputs.source-tarball-name }}
+        # `build-frontend = "build[uv]"` (pyproject.toml) requires uv to be
+        # available on the runner for Windows and macOS. Installing
+        # cibuildwheel with the `uv` extra bundles uv with it; Linux
+        # already has uv inside the manylinux/musllinux container.
+        extras: uv
 
     - name: Upload built artifacts for testing and publishing
       uses: actions/upload-artifact@v7

--- a/CHANGES/764.contrib.rst
+++ b/CHANGES/764.contrib.rst
@@ -1,0 +1,6 @@
+Switched the ``cibuildwheel`` build frontend to ``build[uv]`` so
+that ``uv`` provisions every build and test virtual environment
+in the wheel matrix. Test-dependency installation in particular
+drops from a multi-second ``pip install`` per ABI to a roughly
+sub-second ``uv`` resolve
+-- by :user:`bdraco`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,16 +143,13 @@ known-third-party = ["pytest"]
 
 [tool.cibuildwheel]
 enable = ["cpython-freethreading"]
-build-frontend = "build"
-before-test = [
-  # NOTE: Attempt to have pip pre-compile PyYAML wheel with our build
-  # NOTE: constraints unset. The hope is that pip will cache that wheel
-  # NOTE: and the test env provisioning stage will pick up PyYAML from
-  # NOTE: said cache rather than attempting to build it with a conflicting.
-  # NOTE: Version of Cython.
-  # Ref: https://github.com/pypa/cibuildwheel/issues/1666
-  "PIP_CONSTRAINT= pip install PyYAML",
-]
+# `build[uv]` makes cibuildwheel use `uv` for every venv it provisions,
+# both on the build side (passed to `python -m build` as `--installer=uv`)
+# and when materializing the test environment. uv resolves and installs
+# the wheel plus test dependencies in roughly a second; the previous
+# pip-based path took noticeably longer per ABI and ran once per matrix
+# cell.
+build-frontend = "build[uv]"
 # test-requires = "-r requirements/ci-wheel.txt"
 # test-command = "pytest -v --no-cov {project}/tests"
 
@@ -169,6 +166,3 @@ PY_COLORS = "1"
 
 [tool.cibuildwheel.config-settings]
 pure-python = "false"
-
-[tool.cibuildwheel.windows]
-before-test = []  # Windows cmd has different syntax and pip chooses wheels


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Set ``build-frontend = "build[uv]"`` in ``[tool.cibuildwheel]``
so that ``uv`` provisions every virtual environment cibuildwheel
creates, both on the build side (passed to ``python -m build``
as ``--installer=uv``) and when materializing the per-ABI test
environment. The previous ``build-frontend = "build"`` left every
build/test env doing a multi-second pip resolve per ABI; ``uv``
resolves and installs the same set in roughly a second, which
compounds across the wheel matrix.

Passes ``extras: uv`` to the ``pypa/cibuildwheel`` action so uv
is available on the Windows and macOS runners. Linux already has
uv inside the manylinux/musllinux container.

Also drops the ``before-test`` PyYAML pre-cache hook (a
pip-build-isolation workaround per pypa/cibuildwheel#1666) and
the now-empty ``[tool.cibuildwheel.windows]`` override: uv
handles build constraints through ``UV_BUILD_CONSTRAINT`` rather
than propagating ``PIP_CONSTRAINT`` into source builds, so the
original conflict does not arise.

Ports aio-libs/propcache#234 over to frozenlist.

## Are there changes in behavior for the user?

No, contributor tooling only.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist: N/A (CI-only change; the wheel-matrix run on this PR is the verification path)
- [x] Documentation reflects the changes: N/A (no user-visible API change)
- [x] If you provide code modifications, please add yourself to ``CONTRIBUTORS.txt``: N/A (no such file in this repo)
- [x] Add a new news fragment into the ``CHANGES`` folder (``CHANGES/764.contrib.rst``)

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Local validation:

```
$ python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"
$ make doc-spelling
1 pre-existing misspelling only ("unobvious" in CHANGES/README.rst); CHANGES/764.contrib.rst is clean ("frontend" was already in docs/spelling_wordlist.txt).
$ SKIP=actionlint-docker pre-commit run --files .github/workflows/reusable-cibuildwheel.yml pyproject.toml CHANGES/764.contrib.rst
all hooks pass (actionlint-docker skipped: Docker daemon not running locally; runs in CI).
```

Not verified locally: the actual cibuildwheel + uv interaction
inside the build container; that requires running cibuildwheel
which is impractical without pushing. The live CI run on this
branch is the verification. Existing ``PIP_CONSTRAINT`` in
``[tool.cibuildwheel.environment]`` is left in place; uv ignores
it (uv reads ``UV_CONSTRAINT`` / ``UV_BUILD_CONSTRAINT``), and if
the wheel build ends up needing the Cython pin to apply during
uv-driven build dependency resolution, a follow-up can add a
parallel ``UV_BUILD_CONSTRAINT`` entry.
</details>