### PR TITLE
Install Python via astral-sh/setup-uv and use uv pip everywhere

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,7 +38,7 @@ env:
   PY_COLORS: 1  # Recognized by the `py` package, dependency of `pytest`
   PYTHONIOENCODING: utf-8
   PYTHONUTF8: 1
-  PYTHON_LATEST: 3.x
+  PYTHON_LATEST: 3.14
 
 
 jobs:
@@ -76,21 +76,13 @@ jobs:
     - name: Checkout project
       uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ env.PYTHON_LATEST }}
-    - name: >-
-        Calculate dependency files' combined hash value
-        for use in the cache key
-      id: calc-cache-key-files
-      uses: ./.github/actions/cache-keys
-    - name: Set up pip cache
-      uses: re-actors/cache-python-deps@release/v1
-      with:
-        cache-key-for-dependency-files: >-
-          ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
+        activate-environment: true
+        enable-cache: true
     - name: Install core libraries for build
-      run: python -Im pip install build
+      run: uv pip install build
     - name: Build sdists and pure-python wheel
       run: python -Im build --config-setting=pure-python=true
     - name: Determine actual created filenames
@@ -270,65 +262,22 @@ jobs:
 
     - name: Setup Python ${{ matrix.pyver }}
       id: python-install
-      uses: actions/setup-python@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.pyver }}
-        allow-prereleases: true
-    - name: >-
-        Calculate dependency files' combined hash value
-        for use in the cache key
-      id: calc-cache-key-files
-      uses: ./.github/actions/cache-keys
-    - name: Set up pip cache
-      uses: re-actors/cache-python-deps@release/v1
-      with:
-        cache-key-for-dependency-files: >-
-          ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
+        activate-environment: true
+        enable-cache: true
     - name: Install dependencies
-      uses: py-actions/py-dependency-install@v4
-      with:
-        path: requirements/test.txt
-    - name: Determine pre-compiled compatible wheel
-      env:
-        # NOTE: When `pip` is forced to colorize output piped into `jq`,
-        # NOTE: the latter can't parse it. So we're overriding the color
-        # NOTE: preference here via https://no-color.org.
-        # NOTE: Setting `FORCE_COLOR` to any value (including 0, an empty
-        # NOTE: string, or a "YAML null" `~`) doesn't have any effect and
-        # NOTE: `pip` (through its verndored copy of `rich`) treats the
-        # NOTE: presence of the variable as "force-color" regardless.
-        #
-        # NOTE: This doesn't actually work either, so we'll resort to unsetting
-        # NOTE: in the Bash script.
-        # NOTE: Ref: https://github.com/Textualize/rich/issues/2622
-        NO_COLOR: 1
-      id: wheel-file
-      run: >
-        echo -n path= | tee -a "${GITHUB_OUTPUT}"
-
-
-        unset FORCE_COLOR
-
-
-        python
-        -X utf8
-        -u -I
-        -m pip install
+      run: uv pip install -r requirements/test.txt
+    - name: Install ${{ env.PROJECT_NAME }} from a pre-built wheel
+      run: >-
+        uv pip install
         --find-links=./dist
         --no-index
-        '${{ env.PROJECT_NAME }}'
-        --force-reinstall
-        --no-color
         --no-deps
+        --force-reinstall
         --only-binary=:all:
-        --dry-run
-        --report=-
-        --quiet
-        | jq --raw-output .install[].download_info.url
-        | tee -a "${GITHUB_OUTPUT}"
-      shell: bash
-    - name: Self-install
-      run: python -Im pip install '${{ steps.wheel-file.outputs.path }}'
+        '${{ env.PROJECT_NAME }}'
     - name: Produce the C-files for the Coverage.py Cython plugin
       if: >-  # Only works if the dists were built with line tracing
         !matrix.no-extensions
@@ -341,7 +290,7 @@ jobs:
       run: |
         set -eEuo pipefail
 
-        python -Im pip install expandvars
+        uv pip install expandvars
         python -m pep517_backend.cli translate-cython
       shell: bash
     - name: Disable the Cython.Coverage Produce plugin

--- a/CHANGES/768.contrib.rst
+++ b/CHANGES/768.contrib.rst
@@ -1,0 +1,6 @@
+Switched the CI test matrix from ``actions/setup-python`` to
+``astral-sh/setup-uv`` for installing interpreters, cutting the
+``Setup Python`` step from tens of seconds to a few seconds on
+macOS and Windows runners for variants not in the hosted
+tool-cache (notably the free-threaded ``3.14t``)
+-- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -159,6 +159,7 @@ login
 lookup
 lookups
 lossless
+macOS
 Mako
 Martijn
 manylinux


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Swap `actions/setup-python@v6` for `astral-sh/setup-uv@v8.1.0` in the
two CI jobs that install a Python interpreter (the
``build-pure-python-dists`` step and the matrix ``test`` step) and
let uv own dependency installation across the rest of the job:

- ``activate-environment: true`` keeps ``python``/``pip`` on PATH so
  every subsequent step still finds them.
- ``enable-cache: true`` switches to uv's built-in cache, dropping
  the ``./.github/actions/cache-keys`` + ``re-actors/cache-python-deps``
  pair from these two jobs (those actions remain in use from
  ``reusable-linters.yml``).
- ``py-actions/py-dependency-install`` becomes ``uv pip install -r
  requirements/test.txt``; the ``python -Im pip install build`` and
  ``python -Im pip install expandvars`` calls become ``uv pip
  install``.
- The ``Determine pre-compiled compatible wheel`` step that piped
  ``pip install --dry-run --report`` through ``jq`` to extract a
  wheel URL, then fed it to a ``Self-install`` step, collapses into
  a single ``uv pip install --find-links=./dist --no-index
  --no-deps --force-reinstall --only-binary=:all:`` invocation.

## Are there changes in behavior for the user?

No. This only affects CI runner provisioning. End-user-visible
behavior of ``frozenlist`` is unaffected.

The Codecov flag derived from
``steps.python-install.outputs.python-version`` now reports the
matrix spec (``3.14t``) rather than the resolved patch
(``3.14.5t``); coarser, but easier to group across patch releases.

## Is it a substantial burden for the maintainer to support this?

No. ``astral-sh/setup-uv`` is widely used across aio-libs and the
broader Python ecosystem; ``activate-environment: true`` reproduces
the PATH shape the existing pipeline already relies on, and
``uv pip install`` is a drop-in for the handful of ``pip install``
call-sites that remain.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist; N/A (CI configuration)
- [x] Documentation reflects the changes; N/A (no user-visible change)
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``
- [x] Add a new news fragment into the ``CHANGES/`` folder (``768.contrib.rst``)

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

Mirrors aio-libs/yarl#1704. ``astral-sh/setup-uv`` fetches
python-build-standalone from a CDN, which is consistently a few
seconds across Linux, macOS, and Windows. The wins are largest for
matrix entries whose interpreters are not in the GitHub-hosted
tool-cache (free-threaded and pre-release variants on macOS and
Windows).

The wheel-detection rewrite is the second motivation: ``uv pip
install`` already prefers a local ``--find-links`` source over the
index, so the two-step ``--dry-run --report | jq`` + ``Self-install``
dance from before is replaced by one ``uv pip install`` with the
same flags the dry-run was previously asserting.

</details>