### PR TITLE
ci: build aarch64 and armv7l wheels on native ARM runners

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -438,11 +438,38 @@ jobs:
         tag:
         - ''
         - musllinux
+        include:
+        # Build aarch64 natively on the GH-hosted ARM runner instead of
+        # x86_64-under-QEMU; this drops the build from ~40 min of emulation
+        # to a few minutes of native execution. Each `(qemu, tag)` combo
+        # is listed explicitly so the include unambiguously augments the
+        # existing matrix cell rather than relying on the partial-key
+        # merge behaviour of `matrix.include`.
+        - qemu: aarch64
+          tag: ''
+          runner-vm-os: ubuntu-24.04-arm
+          native-arch: true
+        - qemu: aarch64
+          tag: musllinux
+          runner-vm-os: ubuntu-24.04-arm
+          native-arch: true
+        # armv7l also builds on aarch64 hosts. We still register QEMU so
+        # binfmt picks up the 32-bit ARM userspace handler regardless of
+        # whether the host kernel has CONFIG_COMPAT enabled. Even with
+        # emulation, aarch64-on-aarch64 hosting beats x86_64 by a wide
+        # margin.
+        - qemu: armv7l
+          tag: ''
+          runner-vm-os: ubuntu-24.04-arm
+        - qemu: armv7l
+          tag: musllinux
+          runner-vm-os: ubuntu-24.04-arm
     uses: ./.github/workflows/reusable-cibuildwheel.yml
     with:
       check-name: >-
         Build ${{ matrix.tag }} wheels for ${{ matrix.qemu }}
-      qemu: true
+      qemu: ${{ ! matrix.native-arch }}
+      runner-vm-os: ${{ matrix.runner-vm-os || 'ubuntu-latest' }}
       timeout-minutes: 25
       source-tarball-name: >-
         ${{ needs.build-pure-python-dists.outputs.sdist-filename }}

--- a/CHANGES/774.contrib.rst
+++ b/CHANGES/774.contrib.rst
@@ -1,0 +1,5 @@
+Switched the aarch64 and armv7l wheel builds to GitHub's native ARM
+runners. The aarch64 wheels now build without QEMU emulation, and
+armv7l runs on aarch64 hosts so its 32-bit ARM execution is far
+cheaper than the previous aarch64-on-x86_64 path
+-- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,3 +1,4 @@
+aarch
 abc
 aiodns
 aioes


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Move the aarch64 and armv7l legs of the odd-arch wheel matrix off the
x86_64 QEMU path and onto GitHub's public ``ubuntu-24.04-arm`` hosted
runner. aarch64 now builds natively with no emulation. armv7l still
gets ``docker/setup-qemu-action`` so binfmt registers a 32-bit ARM
handler whether or not the host kernel ships ``CONFIG_COMPAT``; even
under emulation, running on an aarch64 host is far cheaper than the
previous aarch64-on-x86_64 layout.

ppc64le, s390x, and riscv64 keep the ``ubuntu-latest`` + QEMU setup
since there are no native GH-hosted runners for those.

The matrix gains an ``include:`` block that overrides ``runner-vm-os``
and a ``native-arch`` flag per arch; the job-level ``qemu`` and
``runner-vm-os`` expressions fall back to the previous behaviour for
the unmodified arches.

This is a port of [aio-libs/yarl#1724][y1724] to ``frozenlist``; the
``reusable-cibuildwheel.yml`` already exposes a ``runner-vm-os`` input
so no change to the reusable workflow is needed.

[y1724]: https://github.com/aio-libs/yarl/pull/1724

## Are there changes in behavior for the user?

No. Wheels are still built for the same architectures and tags; only
the host that builds them changes. CI time on the aarch64 leg should
drop significantly.

## Related issue number

No tracking issue; mirrors aio-libs/yarl#1724.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist — N/A (CI-only change, exercised by the next build run)
- [ ] Documentation reflects the changes — N/A
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt`` — already listed
- [x] Add a new news fragment into the ``CHANGES/`` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (claude-opus-4-7); reviewed by @bdraco.

Local validation:
- ``pre-commit run --files .github/workflows/ci-cd.yml CHANGES/774.contrib.rst docs/spelling_wordlist.txt`` — passed (yamllint, actionlint, GH workflow validation, codespell).
- ``python -c "yaml.safe_load(open('.github/workflows/ci-cd.yml'))"`` confirms the matrix ``include:`` shape and the ``${{ ! matrix.native-arch }}`` / ``${{ matrix.runner-vm-os || 'ubuntu-latest' }}`` expressions parse cleanly.
- ``make doc-spelling`` reports only the pre-existing ``unobvious`` misspelling in ``CHANGES/README.rst`` on master; the new fragment introduces ``aarch`` only, which is added to ``docs/spelling_wordlist.txt``.

Not validated locally: actual native-ARM cibuildwheel run. The runner label and matrix wiring look correct, but the real proof is the first CI run on this branch.
</details>