### PR TITLE
tests: cover both directions of the NO_EXTENSIONS import branch

### DIFF
--- a/CHANGES/782.contrib.rst
+++ b/CHANGES/782.contrib.rst
@@ -2,6 +2,6 @@ Added tests that re-import ``frozenlist`` with
 ``FROZENLIST_NO_EXTENSIONS`` set and unset, so every Codecov
 upload exercises both directions of the import-time
 ``if not NO_EXTENSIONS:`` branch in
-``frozenlist/__init__.py`` and the ``codecov/project/lib``
+:file:`frozenlist/__init__.py` and the ``codecov/project/lib``
 gate no longer treats it as a one-sided partial
 -- by :user:`bdraco`.

--- a/CHANGES/782.contrib.rst
+++ b/CHANGES/782.contrib.rst
@@ -1,7 +1,7 @@
-Added tests that re-import :mod:`frozenlist` with
+Added tests that re-import ``frozenlist`` with
 ``FROZENLIST_NO_EXTENSIONS`` set and unset, so every Codecov
 upload exercises both directions of the import-time
 ``if not NO_EXTENSIONS:`` branch in
-:file:`frozenlist/__init__.py` and the ``codecov/project/lib``
+``frozenlist/__init__.py`` and the ``codecov/project/lib``
 gate no longer treats it as a one-sided partial
 -- by :user:`bdraco`.

--- a/CHANGES/782.contrib.rst
+++ b/CHANGES/782.contrib.rst
@@ -1,0 +1,7 @@
+Added tests that re-import :mod:`frozenlist` with
+``FROZENLIST_NO_EXTENSIONS`` set and unset, so every Codecov
+upload exercises both directions of the import-time
+``if not NO_EXTENSIONS:`` branch in
+:file:`frozenlist/__init__.py` and the ``codecov/project/lib``
+gate no longer treats it as a one-sided partial
+-- by :user:`bdraco`.

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -1,6 +1,8 @@
 # FIXME:
 # mypy: disable-error-code="misc"
 
+import importlib
+import sys
 from collections.abc import MutableSequence
 from copy import copy, deepcopy
 
@@ -417,3 +419,22 @@ class TestFrozenList(FrozenListMixin):
 
 class TestFrozenListPy(FrozenListMixin):
     FrozenList = PyFrozenList  # type: ignore[assignment]  # FIXME
+
+
+def test_reimport_with_no_extensions_uses_pure_python(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FROZENLIST_NO_EXTENSIONS", "1")
+    monkeypatch.delitem(sys.modules, "frozenlist", raising=False)
+    reloaded = importlib.import_module("frozenlist")
+    assert reloaded.NO_EXTENSIONS is True
+    assert reloaded.FrozenList is reloaded.PyFrozenList
+
+
+def test_reimport_without_no_extensions_attempts_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("FROZENLIST_NO_EXTENSIONS", raising=False)
+    monkeypatch.delitem(sys.modules, "frozenlist", raising=False)
+    reloaded = importlib.import_module("frozenlist")
+    assert reloaded.NO_EXTENSIONS is False


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add two tests that re-import the package under ``monkeypatch``
with ``FROZENLIST_NO_EXTENSIONS`` both set and unset, so every
Codecov upload exercises both directions of the import-time
``if not NO_EXTENSIONS:`` branch in ``frozenlist/__init__.py``.

Until now each CI matrix job only ran one direction of that
branch (depending on its ``FROZENLIST_NO_EXTENSIONS`` value),
so every upload reported the line as a one-sided partial.
Codecov does not merge the two opposite partials across
uploads, which left the ``codecov/project/lib`` gate stuck at
98.38% (target 100%) on every PR; see #780 for one example.

## Are there changes in behavior for the user?

No.

## Related issue number

No linked issue; closes the persistent failure of
``codecov/project/lib`` on recent PRs (#780, #779, #777, #774,
and others).

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes — N/A, no user-facing change
- [ ] If you provide code modifications, please add yourself to ``CONTRIBUTORS.txt``
- [x] Add a new news fragment into the ``CHANGES`` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Local verification, both legs at 100% coverage on ``frozenlist/__init__.py``:

```
$ COVERAGE_CORE=ctrace python -m pytest tests/test_frozenlist.py \
    --cov=frozenlist --cov-branch --cov-report=term-missing -q
frozenlist/__init__.py        62      0     14      0   100%
112 passed in 0.18s

$ FROZENLIST_NO_EXTENSIONS=1 COVERAGE_CORE=ctrace python -m pytest \
    tests/test_frozenlist.py --cov=frozenlist --cov-branch \
    --cov-report=term-missing -q
frozenlist/__init__.py        62      0     14      0   100%
112 passed in 0.16s
```

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.
</details>