### PR TITLE
Contrib: small code-quality fixes (static analysis sample)

### DIFF
--- a/CHANGES/820.contrib.rst
+++ b/CHANGES/820.contrib.rst
@@ -2,4 +2,4 @@ Removed duplicate entries in test skip sets, simplified boolean
 assertions in tests, dropped unnecessary ``else`` after ``raise`` in
 ``FrozenList.__hash__``, combined nested context managers in the
 PEP 517 backend, and aligned import lint suppressions with current
-Ruff conventions -- by :user:`inquilabee`.
+``ruff`` conventions -- by :user:`inquilabee`.

--- a/CHANGES/820.contrib.rst
+++ b/CHANGES/820.contrib.rst
@@ -1,5 +1,5 @@
 Removed duplicate entries in test skip sets, simplified boolean
 assertions in tests, dropped unnecessary ``else`` after ``raise`` in
-``FrozenList.__hash__``, combined nested context managers in the
-PEP 517 backend, and aligned import lint suppressions with current
-``ruff`` conventions -- by :user:`inquilabee`.
+``__hash__``, combined nested context managers in the PEP 517
+backend, and aligned import lint suppressions with current ruff
+conventions -- by :user:`inquilabee`.

--- a/CHANGES/820.contrib.rst
+++ b/CHANGES/820.contrib.rst
@@ -1,5 +1,5 @@
 Removed duplicate entries in test skip sets, simplified boolean
 assertions in tests, dropped unnecessary ``else`` after ``raise`` in
 ``__hash__``, combined nested context managers in the PEP 517
-backend, and aligned import lint suppressions with current ruff
+backend, and aligned unused-import lint ignores with current ruff
 conventions -- by :user:`inquilabee`.

--- a/CHANGES/820.contrib.rst
+++ b/CHANGES/820.contrib.rst
@@ -1,0 +1,5 @@
+Removed duplicate entries in test skip sets, simplified boolean
+assertions in tests, dropped unnecessary ``else`` after ``raise`` in
+``FrozenList.__hash__``, combined nested context managers in the
+PEP 517 backend, and aligned import lint suppressions with current
+Ruff conventions -- by :user:`inquilabee`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ extensions = [
 
 with suppress(ImportError):
     # spelling extension is optional, only add it when installed
-    import sphinxcontrib.spelling  # noqa # type: ignore
+    import sphinxcontrib.spelling  # ruff:ignore[unused-import] # type: ignore
 
     extensions.append("sphinxcontrib.spelling")
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -135,6 +135,7 @@ Indices
 infos
 initializer
 inline
+inquilabee
 intaking
 io
 ip

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -70,8 +70,7 @@ class FrozenList(MutableSequence):
     def __hash__(self):
         if self._frozen:
             return hash(tuple(self))
-        else:
-            raise RuntimeError("Cannot hash unfrozen list.")
+        raise RuntimeError("Cannot hash unfrozen list.")
 
     def __copy__(self):
         new_list = self.__class__(self._items)

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -49,7 +49,7 @@ from ._cython_configuration import (
 from ._cython_configuration import patched_env as _patched_cython_env
 from ._transformers import sanitize_rst_roles
 
-__all__ = (  # noqa: WPS410
+__all__ = (
     'build_sdist',
     'build_wheel',
     'get_requires_for_build_wheel',
@@ -143,7 +143,7 @@ def patched_distutils_cmd_install() -> Iterator[None]:
     # Without this, build_lib puts stuff under `*.data/purelib/` folder
     orig_finalize = _distutils_install_cmd.finalize_options
 
-    def new_finalize_options(self: _distutils_install_cmd) -> None:  # noqa: WPS430
+    def new_finalize_options(self: _distutils_install_cmd) -> None:
         self.install_lib = self.install_platlib
         orig_finalize(self)
 
@@ -294,9 +294,8 @@ def maybe_prebuild_c_extensions(
         cythonize_args = _make_cythonize_cli_args_from_config(config, cython_line_tracing_requested)
         with _patched_cython_env(config['env'], cython_line_tracing_requested):
             _cythonize_cli_cmd(cythonize_args)
-        with patched_distutils_cmd_install():
-            with patched_dist_has_ext_modules():
-                yield
+        with patched_distutils_cmd_install(), patched_dist_has_ext_modules():
+            yield
 
 
 @patched_dist_get_long_description()

--- a/packaging/pep517_backend/_compat.py
+++ b/packaging/pep517_backend/_compat.py
@@ -24,4 +24,4 @@ else:
             os.chdir(original_wd)
 
 
-__all__ = ("chdir_cm", "load_toml_from_string")  # noqa: WPS410
+__all__ = ("chdir_cm", "load_toml_from_string")

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -21,8 +21,6 @@ class FrozenListMixin:
         "__slots__",
         "__static_attributes__",
         "__firstlineno__",
-        "__annotations_cache__",
-        "__annotate_func__",
     }
 
     def test___class_getitem__(self) -> None:
@@ -159,7 +157,7 @@ class FrozenListMixin:
     def test_remove(self) -> None:
         _list = self.FrozenList([1])
         _list.remove(1)
-        assert len(_list) == 0
+        assert not _list
 
     def test_remove_frozen(self) -> None:
         _list = self.FrozenList([1])
@@ -171,7 +169,7 @@ class FrozenListMixin:
     def test_clear(self) -> None:
         _list = self.FrozenList([1])
         _list.clear()
-        assert len(_list) == 0
+        assert not _list
 
     def test_clear_frozen(self) -> None:
         _list = self.FrozenList([1])


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Small code-quality fixes in the pure-Python implementation, PEP 517
backend, docs config, and tests: remove a redundant ``else`` after
``raise``, merge nested ``with`` blocks, drop duplicate set members in
test skip lists, use ``assert not _list`` where appropriate, and update
a stale ``noqa`` to ``ruff:ignore`` in Sphinx config.

## Are there changes in behavior for the user?

No. These are internal style and test clarity changes; public API and
runtime behavior are unchanged.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes (N/A; no doc text changed)
- [ ] If you provide code modifications, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder

## Summary

Our analysis found **117 format or lint autofix opportunities** and about
**38 refactoring suggestions** across the reviewed scope. Security scans
were clean; code duplication is low (~1%); maintainability index and
cyclomatic complexity look good on flagged modules; dead-code scanners
reported unused symbols mostly in docs build config and the packaging
backend. This pull request is a **sample** of safe fixes (5 files, roughly
15 line changes), not a full format pass or refactor cleanup.

## What you are doing right

- No secrets detected in scope (gitleaks); Bandit reported no issues.
- Duplicate code is low (~1% jscpd across Python and other sources).
- Radon maintainability index and cyclomatic complexity ranks look healthy
  on the main package modules (rank A).
- Declared runtime dependencies had no known vulnerabilities (pip-audit).

## What you could improve

- **Dead code:** Vulture and deadcode flagged unused variables and imports
  in `packaging/pep517_backend/` and many unused Sphinx config assignments
  in `docs/conf.py` (follow-up; docs config is often intentionally
  declarative).
- **Dependencies:** deptry reported build-time imports (setuptools, Cython,
  expandvars) not listed as runtime deps in `[project]`; expected for the
  in-tree PEP 517 backend (defer).
- **Refactoring:** About 38 structural suggestions remain (e.g. nested
  ``with`` in other backend modules, test loop patterns); one nested
  ``with`` merge is **included in this PR** in `_backend.py`.
- **Lint / style:** Ruff reported commented-out code and style items in
  `docs/conf.py` and packaging modules (follow-up). **Included in this
  PR:** duplicate set members (B033) in tests, RET504-style ``else`` removal
  in `frozenlist/__init__.py`, import lint directive update in `docs/conf.py`.

### Duplicate code

Duplication is low (~1% lines per jscpd). One small clone in packaging
backend helpers; no action required at this level.

## Changes

- `frozenlist/__init__.py`: remove unnecessary ``else`` after ``raise`` in
  `__hash__`.
- `packaging/pep517_backend/_backend.py`: combine nested context managers;
  drop obsolete flake8 noqa on `__all__` and nested function.
- `packaging/pep517_backend/_compat.py`: drop obsolete noqa on `__all__`.
- `docs/conf.py`: replace legacy ``noqa`` with `ruff:ignore` for optional
  spelling import.
- `tests/test_frozenlist.py`: remove duplicate skip-set entries; use
  ``assert not _list`` after `clear`/`remove`.
- `CHANGES/820.contrib.rst`: towncrier fragment.

## Verification

```bash
python -Im pre_commit run --all-files
FROZENLIST_NO_EXTENSIONS=1 pip install -e . --config-settings=pure-python=true
pytest -rxXs -q
```

All passed locally (112 tests, pre-commit green).

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with an automated coding agent; reviewed by inquilabee.

ShipGate outreach scan: `check --suite full --target .` (271 findings in
report metadata); refactor strict count 38; format/lint autofix candidates
117. Outreach venv used published `shipgate==0.1.6` on Python 3.13.

</details>
