### PR TITLE
Fix pickling for the C extension

### DIFF
--- a/CHANGES/834.bugfix.rst
+++ b/CHANGES/834.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed pickling for ``FrozenList`` instances when the C extension is used -- by :user:`cananoo`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -5,5 +5,6 @@ Edgar Ramírez-Mondragón
 J. Nick Koston
 Marcin Konowalczyk
 Martijn Pieters
+Min Peng
 Pau Freixes
 Paul Colomiets

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -84,11 +84,40 @@ class FrozenList(MutableSequence):
 PyFrozenList = FrozenList
 
 
+_MISSING = object()
+
+
+def _get_frozen_list_state(obj: Any) -> Any:
+    object_getstate = getattr(object, "__getstate__", None)
+    getstate = getattr(type(obj), "__getstate__", None)
+    if getstate is not None and getstate is not object_getstate:
+        return obj.__getstate__()
+
+    dict_state = getattr(obj, "__dict__", None)
+    if dict_state is not None:
+        dict_state = dict_state.copy()
+
+    slot_state = {}
+    for cls in type(obj).__mro__:
+        slots = cls.__dict__.get("__slots__", ())
+        if isinstance(slots, str):
+            slots = (slots,)
+        for slot in slots:
+            if slot in {"_frozen", "_items", "__dict__", "__weakref__"}:
+                continue
+            value = getattr(obj, slot, _MISSING)
+            if value is not _MISSING:
+                slot_state[slot] = value
+
+    if dict_state is None and not slot_state:
+        return None
+    return dict_state, slot_state
+
+
 def _unpickle_frozen_list(
     items: list[Any],
     frozen: bool,
     cls: type[Any] | None = None,
-    state: dict[str, Any] | None = None,
 ) -> Any:
     if cls is None:
         cls = FrozenList
@@ -98,8 +127,6 @@ def _unpickle_frozen_list(
         PyFrozenList.__init__(new_list, items)
     else:
         FrozenList.__init__(new_list, items)
-    if state is not None:
-        new_list.__dict__.update(state)
     if frozen:
         new_list.freeze()
     return new_list

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -1,7 +1,7 @@
 import copy
 import os
 import types
-from collections.abc import MutableSequence
+from collections.abc import Iterator, MutableSequence
 from functools import total_ordering
 from typing import Any
 
@@ -118,6 +118,31 @@ def _has_custom_setstate(obj: Any) -> bool:
     )
 
 
+def _get_slot_name(cls: type[Any], slot: str) -> str:
+    if slot.startswith("__") and not slot.endswith("__"):
+        return f"_{cls.__name__.lstrip('_')}{slot}"
+    return slot
+
+
+def _get_frozen_list_slot_names(cls: type[Any]) -> dict[str, str]:
+    slot_names = {}
+    for owner in cls.__mro__:
+        slots = owner.__dict__.get("__slots__", ())
+        if isinstance(slots, str):
+            slots = (slots,)
+        for slot in slots:
+            if slot in {"_frozen", "_items", "__dict__", "__weakref__"}:
+                continue
+            slot_name = _get_slot_name(owner, slot)
+            slot_names[slot] = slot_name
+            slot_names[slot_name] = slot_name
+    return slot_names
+
+
+def _iter_frozen_list_slots(cls: type[Any]) -> Iterator[str]:
+    yield from _get_frozen_list_slot_names(cls).values()
+
+
 def _get_frozen_list_state(obj: Any) -> Any:
     object_getstate = getattr(object, "__getstate__", None)
     getstate = getattr(type(obj), "__getstate__", None)
@@ -129,16 +154,10 @@ def _get_frozen_list_state(obj: Any) -> Any:
         dict_state = dict_state.copy()
 
     slot_state = {}
-    for cls in type(obj).__mro__:
-        slots = cls.__dict__.get("__slots__", ())
-        if isinstance(slots, str):
-            slots = (slots,)
-        for slot in slots:
-            if slot in {"_frozen", "_items", "__dict__", "__weakref__"}:
-                continue
-            value = getattr(obj, slot, _MISSING)
-            if value is not _MISSING:
-                slot_state[slot] = value
+    for slot in _iter_frozen_list_slots(type(obj)):
+        value = getattr(obj, slot, _MISSING)
+        if value is not _MISSING:
+            slot_state[slot] = value
 
     if _has_custom_setstate(obj):
         if dict_state is None:
@@ -162,11 +181,13 @@ def _restore_frozen_list_state(obj: Any, state: tuple[Any, bool]) -> None:
                 dict_state, slot_state = object_state, {}
             if dict_state is not None:
                 instance_dict = getattr(obj, "__dict__", None)
-                if instance_dict is not None:
-                    instance_dict.update(dict_state)
-                else:
-                    for slot, value in dict_state.items():
-                        setattr(obj, slot, value)
+                slot_names = _get_frozen_list_slot_names(type(obj))
+                for name, value in dict_state.items():
+                    slot_name = slot_names.get(name)
+                    if slot_name is not None or instance_dict is None:
+                        setattr(obj, slot_name or name, value)
+                    else:
+                        instance_dict[name] = value
             for slot, value in slot_state.items():
                 setattr(obj, slot, value)
     if frozen:

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -161,7 +161,12 @@ def _restore_frozen_list_state(obj: Any, state: tuple[Any, bool]) -> None:
             else:
                 dict_state, slot_state = object_state, {}
             if dict_state is not None:
-                obj.__dict__.update(dict_state)
+                instance_dict = getattr(obj, "__dict__", None)
+                if instance_dict is not None:
+                    instance_dict.update(dict_state)
+                else:
+                    for slot, value in dict_state.items():
+                        setattr(obj, slot, value)
             for slot, value in slot_state.items():
                 setattr(obj, slot, value)
     if frozen:

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -2,6 +2,7 @@ import os
 import types
 from collections.abc import MutableSequence
 from functools import total_ordering
+from typing import Any
 
 __version__ = "1.8.1.dev0"
 
@@ -83,7 +84,12 @@ class FrozenList(MutableSequence):
 PyFrozenList = FrozenList
 
 
-def _unpickle_frozen_list(items, frozen, cls=None, state=None):
+def _unpickle_frozen_list(
+    items: list[Any],
+    frozen: bool,
+    cls: type[Any] | None = None,
+    state: dict[str, Any] | None = None,
+) -> Any:
     if cls is None:
         cls = FrozenList
 

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -141,7 +141,10 @@ def _get_frozen_list_state(obj: Any) -> Any:
                 slot_state[slot] = value
 
     if _has_custom_setstate(obj):
-        return dict_state if dict_state is not None else slot_state
+        if dict_state is None:
+            return slot_state
+        dict_state.update(slot_state)
+        return dict_state
     if dict_state is None and not slot_state:
         return None
     return dict_state, slot_state

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import types
 from collections.abc import MutableSequence
@@ -80,11 +81,41 @@ class FrozenList(MutableSequence):
             new_list.freeze()
         return new_list
 
+    def __deepcopy__(self, memo):
+        obj_id = id(self)
+        if obj_id in memo:
+            return memo[obj_id]
+
+        new_list = self.__class__([])
+        memo[obj_id] = new_list
+        new_list._items[:] = [copy.deepcopy(item, memo) for item in self._items]
+
+        if self._frozen:
+            new_list.freeze()
+        return new_list
+
+    def __reduce__(self):
+        cls = self.__class__
+        return (
+            _unpickle_frozen_list,
+            (self._items, self._frozen, cls, True),
+            (_get_frozen_list_state(self), self._frozen),
+            None,
+            None,
+            _restore_frozen_list_state,
+        )
+
 
 PyFrozenList = FrozenList
 
 
 _MISSING = object()
+
+
+def _has_custom_setstate(obj: Any) -> bool:
+    return getattr(type(obj), "__setstate__", None) is not getattr(
+        object, "__setstate__", None
+    )
 
 
 def _get_frozen_list_state(obj: Any) -> Any:
@@ -109,15 +140,36 @@ def _get_frozen_list_state(obj: Any) -> Any:
             if value is not _MISSING:
                 slot_state[slot] = value
 
+    if _has_custom_setstate(obj):
+        return dict_state if dict_state is not None else slot_state
     if dict_state is None and not slot_state:
         return None
     return dict_state, slot_state
+
+
+def _restore_frozen_list_state(obj: Any, state: tuple[Any, bool]) -> None:
+    object_state, frozen = state
+    if object_state is not None:
+        if _has_custom_setstate(obj):
+            obj.__setstate__(object_state)
+        else:
+            if isinstance(object_state, tuple):
+                dict_state, slot_state = object_state
+            else:
+                dict_state, slot_state = object_state, {}
+            if dict_state is not None:
+                obj.__dict__.update(dict_state)
+            for slot, value in slot_state.items():
+                setattr(obj, slot, value)
+    if frozen:
+        obj.freeze()
 
 
 def _unpickle_frozen_list(
     items: list[Any],
     frozen: bool,
     cls: type[Any] | None = None,
+    defer_freeze: bool = False,
 ) -> Any:
     if cls is None:
         cls = FrozenList
@@ -127,7 +179,7 @@ def _unpickle_frozen_list(
         PyFrozenList.__init__(new_list, items)
     else:
         FrozenList.__init__(new_list, items)
-    if frozen:
+    if frozen and not defer_freeze:
         new_list.freeze()
     return new_list
 

--- a/frozenlist/__init__.py
+++ b/frozenlist/__init__.py
@@ -83,6 +83,22 @@ class FrozenList(MutableSequence):
 PyFrozenList = FrozenList
 
 
+def _unpickle_frozen_list(items, frozen, cls=None, state=None):
+    if cls is None:
+        cls = FrozenList
+
+    new_list = cls.__new__(cls)
+    if issubclass(cls, PyFrozenList):
+        PyFrozenList.__init__(new_list, items)
+    else:
+        FrozenList.__init__(new_list, items)
+    if state is not None:
+        new_list.__dict__.update(state)
+    if frozen:
+        new_list.freeze()
+    return new_list
+
+
 if not NO_EXTENSIONS:
     try:
         from ._frozenlist import FrozenList as CFrozenList  # type: ignore

--- a/frozenlist/__init__.pyi
+++ b/frozenlist/__init__.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Iterator, MutableSequence
-from typing import Any, Generic, TypeVar, overload
+from typing import Generic, TypeVar, overload
 
 _T = TypeVar("_T")
 _Arg = list[_T] | Iterable[_T]
@@ -34,13 +34,6 @@ class FrozenList(MutableSequence[_T], Generic[_T]):
     def __repr__(self) -> str: ...
     def __hash__(self) -> int: ...
     def __copy__(self) -> FrozenList[_T]: ...
-
-def _unpickle_frozen_list(
-    items: list[Any],
-    frozen: bool,
-    cls: type[Any] | None = ...,
-    state: dict[str, Any] | None = ...,
-) -> FrozenList[Any]: ...
 
 # types for C accelerators are the same
 CFrozenList = PyFrozenList = FrozenList

--- a/frozenlist/__init__.pyi
+++ b/frozenlist/__init__.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Iterator, MutableSequence
-from typing import Generic, TypeVar, overload
+from typing import Any, Generic, TypeVar, overload
 
 _T = TypeVar("_T")
 _Arg = list[_T] | Iterable[_T]
@@ -34,6 +34,13 @@ class FrozenList(MutableSequence[_T], Generic[_T]):
     def __repr__(self) -> str: ...
     def __hash__(self) -> int: ...
     def __copy__(self) -> FrozenList[_T]: ...
+
+def _unpickle_frozen_list(
+    items: list[Any],
+    frozen: bool,
+    cls: type[Any] | None = ...,
+    state: dict[str, Any] | None = ...,
+) -> FrozenList[Any]: ...
 
 # types for C accelerators are the same
 CFrozenList = PyFrozenList = FrozenList

--- a/frozenlist/_frozenlist.pyx
+++ b/frozenlist/_frozenlist.pyx
@@ -7,7 +7,7 @@ from libcpp.atomic cimport atomic
 import copy
 import types
 from collections.abc import MutableSequence
-from frozenlist import _unpickle_frozen_list
+from frozenlist import _get_frozen_list_state, _unpickle_frozen_list
 
 
 cdef class FrozenList:
@@ -135,9 +135,11 @@ cdef class FrozenList:
         cls = self.__class__
         if cls is FrozenList:
             cls = None
-        return (_unpickle_frozen_list,
-                (self._items, self._frozen.load(), cls,
-                 getattr(self, "__dict__", None)))
+        return (
+            _unpickle_frozen_list,
+            (self._items, self._frozen.load(), cls),
+            _get_frozen_list_state(self),
+        )
 
     def __deepcopy__(self, memo):
         cdef FrozenList new_list

--- a/frozenlist/_frozenlist.pyx
+++ b/frozenlist/_frozenlist.pyx
@@ -9,6 +9,13 @@ import types
 from collections.abc import MutableSequence
 
 
+def _unpickle_frozen_list(cls, items, frozen):
+    new_list = cls(items)
+    if frozen:
+        new_list.freeze()
+    return new_list
+
+
 cdef class FrozenList:
     __class_getitem__ = classmethod(types.GenericAlias)
 
@@ -129,6 +136,10 @@ cdef class FrozenList:
         if self._frozen.load():
             new_list.freeze()
         return new_list
+
+    def __reduce__(self):
+        return (_unpickle_frozen_list,
+                (self.__class__, self._items, self._frozen.load()))
 
     def __deepcopy__(self, memo):
         cdef FrozenList new_list

--- a/frozenlist/_frozenlist.pyx
+++ b/frozenlist/_frozenlist.pyx
@@ -7,13 +7,7 @@ from libcpp.atomic cimport atomic
 import copy
 import types
 from collections.abc import MutableSequence
-
-
-def _unpickle_frozen_list(cls, items, frozen):
-    new_list = cls(items)
-    if frozen:
-        new_list.freeze()
-    return new_list
+from frozenlist import _unpickle_frozen_list
 
 
 cdef class FrozenList:
@@ -138,8 +132,12 @@ cdef class FrozenList:
         return new_list
 
     def __reduce__(self):
+        cls = self.__class__
+        if cls is FrozenList:
+            cls = None
         return (_unpickle_frozen_list,
-                (self.__class__, self._items, self._frozen.load()))
+                (self._items, self._frozen.load(), cls,
+                 getattr(self, "__dict__", None)))
 
     def __deepcopy__(self, memo):
         cdef FrozenList new_list

--- a/frozenlist/_frozenlist.pyx
+++ b/frozenlist/_frozenlist.pyx
@@ -7,7 +7,11 @@ from libcpp.atomic cimport atomic
 import copy
 import types
 from collections.abc import MutableSequence
-from frozenlist import _get_frozen_list_state, _unpickle_frozen_list
+from frozenlist import (
+    _get_frozen_list_state,
+    _restore_frozen_list_state,
+    _unpickle_frozen_list,
+)
 
 
 cdef class FrozenList:
@@ -135,11 +139,10 @@ cdef class FrozenList:
         cls = self.__class__
         if cls is FrozenList:
             cls = None
-        return (
-            _unpickle_frozen_list,
-            (self._items, self._frozen.load(), cls),
-            _get_frozen_list_state(self),
-        )
+        return (_unpickle_frozen_list,
+                (self._items, self._frozen.load(), cls, True),
+                (_get_frozen_list_state(self), self._frozen.load()),
+                None, None, _restore_frozen_list_state)
 
     def __deepcopy__(self, memo):
         cdef FrozenList new_list

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -486,9 +486,7 @@ class TestFrozenListPy(FrozenListMixin):
         (FrozenListStateSubclass, "state"),
     ],
 )
-def test_pickle_subclass(
-    subclass: type[FrozenList[object]], label: str
-) -> None:
+def test_pickle_subclass(subclass: type[FrozenList[object]], label: str) -> None:
     orig = subclass()
     copied = cast(FrozenList[object], _PICKLE_LOADS(_PICKLE_DUMPS(orig)))
     assert type(copied) is subclass

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -20,6 +20,17 @@ class _Labeled(Protocol):
     label: str
 
 
+class _FrozenListModule(Protocol):
+    FrozenList: type[FrozenList[object]]
+    _unpickle_frozen_list: Callable[[list[object], bool], object]
+    _get_frozen_list_state: Callable[[object], object]
+
+
+class _EmptySlots:
+    __slots__ = ("unused",)
+    unused: object
+
+
 class FrozenListSubclass(FrozenList[object]):
     def __init__(self) -> None:
         super().__init__([1, 2, 3])
@@ -483,18 +494,24 @@ class TestFrozenListPy(FrozenListMixin):
 
 
 @pytest.mark.parametrize(
-    "subclass, label",
+    "subclass, label, frozen",
     [
-        (FrozenListSubclass, "subclass"),
-        (FrozenListSlotsSubclass, "slots"),
-        (FrozenListStateSubclass, "state"),
+        (FrozenListSubclass, "subclass", False),
+        (FrozenListSlotsSubclass, "slots", False),
+        (FrozenListStateSubclass, "state", False),
+        (FrozenListStateSubclass, "state", True),
     ],
 )
-def test_pickle_subclass(subclass: type[FrozenList[object]], label: str) -> None:
+def test_pickle_subclass(
+    subclass: type[FrozenList[object]], label: str, frozen: bool
+) -> None:
     orig = subclass()
+    if frozen:
+        orig.freeze()
     copied = cast(FrozenList[object], _PICKLE_LOADS(_PICKLE_DUMPS(orig)))
     assert type(copied) is subclass
     assert copied == orig
+    assert copied.frozen is frozen
     assert cast(_Labeled, copied).label == label
 
 
@@ -503,18 +520,25 @@ def test_unpickle_uses_pure_python(
 ) -> None:
     monkeypatch.setenv("FROZENLIST_NO_EXTENSIONS", "1")
     monkeypatch.delitem(sys.modules, "frozenlist", raising=False)
-    reloaded = importlib.import_module("frozenlist")
-    frozen_list_type = cast(type[FrozenList[object]], reloaded.__dict__["FrozenList"])
-    unpickle = cast(
-        Callable[[list[object], bool], object],
-        reloaded.__dict__["_unpickle_frozen_list"],
-    )
+    reloaded = cast(_FrozenListModule, importlib.import_module("frozenlist"))
+    frozen_list_type = reloaded.FrozenList
+    unpickle = reloaded._unpickle_frozen_list
+    get_state = reloaded._get_frozen_list_state
 
     copied = cast(FrozenList[object], unpickle([1, 2, 3], True))
 
     assert type(copied) is frozen_list_type
     assert copied == [1, 2, 3]
     assert copied.frozen
+    assert get_state(frozen_list_type([1, 2, 3])) is None
+    assert get_state(_EmptySlots()) is None
+    assert get_state(FrozenListSubclass()) == ({"label": "subclass"}, {})
+    assert get_state(FrozenListStateSubclass()) == {
+        "items": [1, 2, 3],
+        "frozen": False,
+        "label": "state",
+    }
+    assert get_state(FrozenListSlotsSubclass()) == (None, {"label": "slots"})
 
 
 def test_reimport_with_no_extensions_uses_pure_python(

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -93,6 +93,30 @@ class FrozenListSlotsGetStateSubclass(FrozenList[object]):
         return {"label": self.label}
 
 
+class FrozenListPrivateSlotsSubclass(FrozenList[object]):
+    __slots__ = "__label"
+
+    def __init__(self) -> None:
+        super().__init__([1, 2, 3])
+        self.__label = "private-slots"
+
+    @property
+    def label(self) -> str:
+        return self.__label
+
+
+class FrozenListDictSlotsGetStateSubclass(FrozenList[object]):
+    __slots__ = ("slot_label", "__dict__")
+
+    def __init__(self) -> None:
+        super().__init__([1, 2, 3])
+        self.label = "dict"
+        self.slot_label = "slot"
+
+    def __getstate__(self) -> dict[str, object]:
+        return {"label": self.label, "slot_label": self.slot_label}
+
+
 class FrozenListSlotsStateSubclass(FrozenList[object]):
     __slots__ = "label"
 
@@ -576,6 +600,7 @@ class TestFrozenListPy(FrozenListMixin):
         (FrozenListDefaultStateSubclass, "default", False),
         (FrozenListGetStateSubclass, "getstate", False),
         (FrozenListSlotsGetStateSubclass, "slots-getstate", False),
+        (FrozenListPrivateSlotsSubclass, "private-slots", False),
         (FrozenListSlotsStateSubclass, "slot-state", False),
     ],
 )
@@ -633,6 +658,19 @@ def test_pickle_subclass_preserves_dict_and_slot_state() -> None:
     assert copied.slot_label == "slot"
 
 
+def test_pickle_subclass_restores_custom_dict_and_slot_state() -> None:
+    orig = FrozenListDictSlotsGetStateSubclass()
+    copied = cast(
+        FrozenListDictSlotsGetStateSubclass,
+        _PICKLE_LOADS(_PICKLE_DUMPS(orig)),
+    )
+
+    assert copied == orig
+    assert copied.label == "dict"
+    assert copied.slot_label == "slot"
+    assert "slot_label" not in copied.__dict__
+
+
 def test_unpickle_uses_pure_python(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -663,6 +701,10 @@ def test_unpickle_uses_pure_python(
         "label": "state",
     }
     assert get_state(FrozenListSlotsSubclass()) == (None, {"label": "slots"})
+    assert get_state(FrozenListPrivateSlotsSubclass()) == (
+        None,
+        {"_FrozenListPrivateSlotsSubclass__label": "private-slots"},
+    )
 
 
 def test_reimport_with_no_extensions_uses_pure_python(

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -22,6 +22,33 @@ class FrozenListSubclass(FrozenList[object]):
         self.label = "subclass"
 
 
+class FrozenListSlotsSubclass(FrozenList[object]):
+    __slots__ = "label"
+
+    def __init__(self) -> None:
+        super().__init__([1, 2, 3])
+        self.label = "slots"
+
+
+class FrozenListStateSubclass(FrozenList[object]):
+    def __init__(self) -> None:
+        super().__init__([1, 2, 3])
+        self.label = "state"
+
+    def __getstate__(self) -> dict[str, object]:
+        return {
+            "items": list(self),
+            "frozen": self.frozen,
+            "label": self.label,
+        }
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        FrozenList.__init__(self, cast(list[object], state["items"]))
+        if cast(bool, state["frozen"]):
+            self.freeze()
+        self.label = cast(str, state["label"])
+
+
 class FrozenListMixin:
     FrozenList = NotImplemented
 
@@ -451,12 +478,40 @@ class TestFrozenListPy(FrozenListMixin):
     FrozenList = PyFrozenList  # type: ignore[assignment]  # FIXME
 
 
-def test_pickle_subclass() -> None:
-    orig = FrozenListSubclass()
-    copied = cast(FrozenListSubclass, _PICKLE_LOADS(_PICKLE_DUMPS(orig)))
-    assert type(copied) is FrozenListSubclass
+@pytest.mark.parametrize(
+    "subclass, label",
+    [
+        (FrozenListSubclass, "subclass"),
+        (FrozenListSlotsSubclass, "slots"),
+        (FrozenListStateSubclass, "state"),
+    ],
+)
+def test_pickle_subclass(
+    subclass: type[FrozenList[object]], label: str
+) -> None:
+    orig = subclass()
+    copied = cast(FrozenList[object], _PICKLE_LOADS(_PICKLE_DUMPS(orig)))
+    assert type(copied) is subclass
     assert copied == orig
-    assert copied.label == "subclass"
+    assert getattr(copied, "label") == label
+
+
+def test_unpickle_uses_pure_python(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FROZENLIST_NO_EXTENSIONS", "1")
+    monkeypatch.delitem(sys.modules, "frozenlist", raising=False)
+    reloaded = importlib.import_module("frozenlist")
+    unpickle = cast(
+        Callable[[list[object], bool], object],
+        getattr(reloaded, "_unpickle_frozen_list"),
+    )
+
+    copied = cast(FrozenList[object], unpickle([1, 2, 3], True))
+
+    assert type(copied) is reloaded.FrozenList
+    assert copied == [1, 2, 3]
+    assert copied.frozen
 
 
 def test_reimport_with_no_extensions_uses_pure_python(

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -304,7 +304,7 @@ class FrozenListMixin:
         frozen_list_type = cast(type[FrozenList[object]], self.FrozenList)
         orig = frozen_list_type([1, 2, 3])
         monkeypatch.setattr(sys.modules["frozenlist"], "FrozenList", frozen_list_type)
-        copied = _PICKLE_LOADS(pickle.dumps(orig))
+        copied = _PICKLE_LOADS(_PICKLE_DUMPS(orig))
         assert isinstance(copied, frozen_list_type)
         assert copied == orig
         assert not copied.frozen
@@ -314,7 +314,7 @@ class FrozenListMixin:
         orig = frozen_list_type([1, 2, 3])
         orig.freeze()
         monkeypatch.setattr(sys.modules["frozenlist"], "FrozenList", frozen_list_type)
-        copied = _PICKLE_LOADS(pickle.dumps(orig))
+        copied = _PICKLE_LOADS(_PICKLE_DUMPS(orig))
         assert isinstance(copied, frozen_list_type)
         assert copied == orig
         assert copied.frozen

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -82,6 +82,17 @@ class FrozenListGetStateSubclass(FrozenList[object]):
         return {"label": self.label}
 
 
+class FrozenListSlotsGetStateSubclass(FrozenList[object]):
+    __slots__ = "label"
+
+    def __init__(self) -> None:
+        super().__init__([1, 2, 3])
+        self.label = "slots-getstate"
+
+    def __getstate__(self) -> dict[str, object]:
+        return {"label": self.label}
+
+
 class FrozenListSlotsStateSubclass(FrozenList[object]):
     __slots__ = "label"
 
@@ -564,6 +575,7 @@ class TestFrozenListPy(FrozenListMixin):
         (FrozenListStateSubclass, "state", True),
         (FrozenListDefaultStateSubclass, "default", False),
         (FrozenListGetStateSubclass, "getstate", False),
+        (FrozenListSlotsGetStateSubclass, "slots-getstate", False),
         (FrozenListSlotsStateSubclass, "slot-state", False),
     ],
 )

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -10,7 +10,7 @@ from typing import cast
 
 import pytest
 
-from frozenlist import FrozenList, PyFrozenList, _unpickle_frozen_list
+from frozenlist import FrozenList, PyFrozenList
 
 _PICKLE_DUMPS = cast(Callable[[object], bytes], pickle.dumps)
 _PICKLE_LOADS = cast(Callable[[bytes], object], pickle.loads)
@@ -457,12 +457,6 @@ def test_pickle_subclass() -> None:
     assert type(copied) is FrozenListSubclass
     assert copied == orig
     assert copied.label == "subclass"
-
-
-def test_pickle_reconstructor() -> None:
-    copied = _unpickle_frozen_list([1, 2, 3], True)
-    assert copied == [1, 2, 3]
-    assert copied.frozen
 
 
 def test_reimport_with_no_extensions_uses_pure_python(

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -504,9 +504,7 @@ def test_unpickle_uses_pure_python(
     monkeypatch.setenv("FROZENLIST_NO_EXTENSIONS", "1")
     monkeypatch.delitem(sys.modules, "frozenlist", raising=False)
     reloaded = importlib.import_module("frozenlist")
-    frozen_list_type = cast(
-        type[FrozenList[object]], reloaded.__dict__["FrozenList"]
-    )
+    frozen_list_type = cast(type[FrozenList[object]], reloaded.__dict__["FrozenList"])
     unpickle = cast(
         Callable[[list[object], bool], object],
         reloaded.__dict__["_unpickle_frozen_list"],

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -10,13 +10,30 @@ from typing import cast
 
 import pytest
 
-from frozenlist import FrozenList, PyFrozenList
+from frozenlist import (  # type: ignore[attr-defined]
+    FrozenList,
+    PyFrozenList,
+    _unpickle_frozen_list,
+)
 
 _PICKLE_LOADS = cast(Callable[[bytes], object], pickle.loads)
 
 
+class FrozenListSubclass(FrozenList):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__([1, 2, 3])
+        self.label = "subclass"
+
+
+class PyFrozenListSubclass(PyFrozenList):  # type: ignore[valid-type]
+    def __init__(self) -> None:
+        super().__init__([1, 2, 3])
+        self.label = "subclass"
+
+
 class FrozenListMixin:
     FrozenList = NotImplemented
+    Subclass: type[object]
 
     SKIP_METHODS = {
         "__abstractmethods__",
@@ -312,6 +329,25 @@ class FrozenListMixin:
         assert copied == orig
         assert copied.frozen
 
+    def test_pickle_subclass(self) -> None:
+        orig = self.Subclass()
+        copied = _PICKLE_LOADS(pickle.dumps(orig))
+        assert type(copied) is self.Subclass
+        assert copied == orig
+        assert getattr(copied, "label") == "subclass"
+
+    def test_pickle_reconstructor(self) -> None:
+        copied = _unpickle_frozen_list([1, 2, 3], True)
+        assert isinstance(copied, FrozenList)
+        assert copied.frozen
+
+        copied_subclass = _unpickle_frozen_list(
+            [1, 2, 3], False, self.Subclass, {"label": "subclass"}
+        )
+        assert type(copied_subclass) is self.Subclass
+        assert copied_subclass == [1, 2, 3]
+        assert getattr(copied_subclass, "label") == "subclass"
+
     def test_deepcopy_unfrozen(self) -> None:
         orig = self.FrozenList([1, 2, 3])
         copied = deepcopy(orig)
@@ -438,10 +474,12 @@ class FrozenListMixin:
 
 class TestFrozenList(FrozenListMixin):
     FrozenList = FrozenList  # type: ignore[assignment]  # FIXME
+    Subclass = FrozenListSubclass
 
 
 class TestFrozenListPy(FrozenListMixin):
     FrozenList = PyFrozenList  # type: ignore[assignment]  # FIXME
+    Subclass = PyFrozenListSubclass
 
 
 def test_reimport_with_no_extensions_uses_pure_python(

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -10,22 +10,13 @@ from typing import cast
 
 import pytest
 
-from frozenlist import (  # type: ignore[attr-defined]
-    FrozenList,
-    PyFrozenList,
-    _unpickle_frozen_list,
-)
+from frozenlist import FrozenList, PyFrozenList, _unpickle_frozen_list
 
+_PICKLE_DUMPS = cast(Callable[[object], bytes], pickle.dumps)
 _PICKLE_LOADS = cast(Callable[[bytes], object], pickle.loads)
 
 
-class FrozenListSubclass(FrozenList):  # type: ignore[type-arg]
-    def __init__(self) -> None:
-        super().__init__([1, 2, 3])
-        self.label = "subclass"
-
-
-class PyFrozenListSubclass(PyFrozenList):  # type: ignore[valid-type]
+class FrozenListSubclass(FrozenList[object]):
     def __init__(self) -> None:
         super().__init__([1, 2, 3])
         self.label = "subclass"
@@ -33,7 +24,6 @@ class PyFrozenListSubclass(PyFrozenList):  # type: ignore[valid-type]
 
 class FrozenListMixin:
     FrozenList = NotImplemented
-    Subclass: type[object]
 
     SKIP_METHODS = {
         "__abstractmethods__",
@@ -329,25 +319,6 @@ class FrozenListMixin:
         assert copied == orig
         assert copied.frozen
 
-    def test_pickle_subclass(self) -> None:
-        orig = self.Subclass()
-        copied = _PICKLE_LOADS(pickle.dumps(orig))
-        assert type(copied) is self.Subclass
-        assert copied == orig
-        assert getattr(copied, "label") == "subclass"
-
-    def test_pickle_reconstructor(self) -> None:
-        copied = _unpickle_frozen_list([1, 2, 3], True)
-        assert isinstance(copied, FrozenList)
-        assert copied.frozen
-
-        copied_subclass = _unpickle_frozen_list(
-            [1, 2, 3], False, self.Subclass, {"label": "subclass"}
-        )
-        assert type(copied_subclass) is self.Subclass
-        assert copied_subclass == [1, 2, 3]
-        assert getattr(copied_subclass, "label") == "subclass"
-
     def test_deepcopy_unfrozen(self) -> None:
         orig = self.FrozenList([1, 2, 3])
         copied = deepcopy(orig)
@@ -474,12 +445,24 @@ class FrozenListMixin:
 
 class TestFrozenList(FrozenListMixin):
     FrozenList = FrozenList  # type: ignore[assignment]  # FIXME
-    Subclass = FrozenListSubclass
 
 
 class TestFrozenListPy(FrozenListMixin):
     FrozenList = PyFrozenList  # type: ignore[assignment]  # FIXME
-    Subclass = PyFrozenListSubclass
+
+
+def test_pickle_subclass() -> None:
+    orig = FrozenListSubclass()
+    copied = cast(FrozenListSubclass, _PICKLE_LOADS(_PICKLE_DUMPS(orig)))
+    assert type(copied) is FrozenListSubclass
+    assert copied == orig
+    assert copied.label == "subclass"
+
+
+def test_pickle_reconstructor() -> None:
+    copied = _unpickle_frozen_list([1, 2, 3], True)
+    assert copied == [1, 2, 3]
+    assert copied.frozen
 
 
 def test_reimport_with_no_extensions_uses_pure_python(

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -6,7 +6,7 @@ import pickle
 import sys
 from collections.abc import Callable, MutableSequence
 from copy import copy, deepcopy
-from typing import cast
+from typing import Protocol, cast
 
 import pytest
 
@@ -14,6 +14,10 @@ from frozenlist import FrozenList, PyFrozenList
 
 _PICKLE_DUMPS = cast(Callable[[object], bytes], pickle.dumps)
 _PICKLE_LOADS = cast(Callable[[bytes], object], pickle.loads)
+
+
+class _Labeled(Protocol):
+    label: str
 
 
 class FrozenListSubclass(FrozenList[object]):
@@ -491,7 +495,7 @@ def test_pickle_subclass(subclass: type[FrozenList[object]], label: str) -> None
     copied = cast(FrozenList[object], _PICKLE_LOADS(_PICKLE_DUMPS(orig)))
     assert type(copied) is subclass
     assert copied == orig
-    assert getattr(copied, "label") == label
+    assert cast(_Labeled, copied).label == label
 
 
 def test_unpickle_uses_pure_python(
@@ -500,14 +504,17 @@ def test_unpickle_uses_pure_python(
     monkeypatch.setenv("FROZENLIST_NO_EXTENSIONS", "1")
     monkeypatch.delitem(sys.modules, "frozenlist", raising=False)
     reloaded = importlib.import_module("frozenlist")
+    frozen_list_type = cast(
+        type[FrozenList[object]], reloaded.__dict__["FrozenList"]
+    )
     unpickle = cast(
         Callable[[list[object], bool], object],
-        getattr(reloaded, "_unpickle_frozen_list"),
+        reloaded.__dict__["_unpickle_frozen_list"],
     )
 
     copied = cast(FrozenList[object], unpickle([1, 2, 3], True))
 
-    assert type(copied) is reloaded.FrozenList
+    assert type(copied) is frozen_list_type
     assert copied == [1, 2, 3]
     assert copied.frozen
 

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -6,6 +6,7 @@ import pickle
 import sys
 from collections.abc import MutableSequence
 from copy import copy, deepcopy
+from typing import cast
 
 import pytest
 
@@ -293,7 +294,7 @@ class FrozenListMixin:
     def test_pickle_unfrozen(self, monkeypatch: pytest.MonkeyPatch) -> None:
         orig = self.FrozenList([1, 2, 3])
         monkeypatch.setattr(sys.modules["frozenlist"], "FrozenList", self.FrozenList)
-        copied = pickle.loads(pickle.dumps(orig))
+        copied = cast(FrozenList[object], pickle.loads(pickle.dumps(orig)))
         assert copied == orig
         assert not copied.frozen
 
@@ -301,7 +302,7 @@ class FrozenListMixin:
         orig = self.FrozenList([1, 2, 3])
         orig.freeze()
         monkeypatch.setattr(sys.modules["frozenlist"], "FrozenList", self.FrozenList)
-        copied = pickle.loads(pickle.dumps(orig))
+        copied = cast(FrozenList[object], pickle.loads(pickle.dumps(orig)))
         assert copied == orig
         assert copied.frozen
 

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -4,13 +4,16 @@
 import importlib
 import pickle
 import sys
-from collections.abc import MutableSequence
+from collections.abc import Callable, MutableSequence
 from copy import copy, deepcopy
 from typing import cast
 
 import pytest
 
 from frozenlist import FrozenList, PyFrozenList
+
+
+_PICKLE_LOADS = cast(Callable[[bytes], object], pickle.loads)
 
 
 class FrozenListMixin:
@@ -292,17 +295,21 @@ class FrozenListMixin:
         assert len(copied) == 2
 
     def test_pickle_unfrozen(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        orig = self.FrozenList([1, 2, 3])
-        monkeypatch.setattr(sys.modules["frozenlist"], "FrozenList", self.FrozenList)
-        copied = cast(FrozenList[object], pickle.loads(pickle.dumps(orig)))
+        frozen_list_type = cast(type[FrozenList[object]], self.FrozenList)
+        orig = frozen_list_type([1, 2, 3])
+        monkeypatch.setattr(sys.modules["frozenlist"], "FrozenList", frozen_list_type)
+        copied = _PICKLE_LOADS(pickle.dumps(orig))
+        assert isinstance(copied, frozen_list_type)
         assert copied == orig
         assert not copied.frozen
 
     def test_pickle_frozen(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        orig = self.FrozenList([1, 2, 3])
+        frozen_list_type = cast(type[FrozenList[object]], self.FrozenList)
+        orig = frozen_list_type([1, 2, 3])
         orig.freeze()
-        monkeypatch.setattr(sys.modules["frozenlist"], "FrozenList", self.FrozenList)
-        copied = cast(FrozenList[object], pickle.loads(pickle.dumps(orig)))
+        monkeypatch.setattr(sys.modules["frozenlist"], "FrozenList", frozen_list_type)
+        copied = _PICKLE_LOADS(pickle.dumps(orig))
+        assert isinstance(copied, frozen_list_type)
         assert copied == orig
         assert copied.frozen
 

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -12,7 +12,6 @@ import pytest
 
 from frozenlist import FrozenList, PyFrozenList
 
-
 _PICKLE_LOADS = cast(Callable[[bytes], object], pickle.loads)
 
 

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -64,6 +64,55 @@ class FrozenListStateSubclass(FrozenList[object]):
         self.label = cast(str, state["label"])
 
 
+class FrozenListDefaultStateSubclass(FrozenList[object]):
+    def __init__(self) -> None:
+        super().__init__([1, 2, 3])
+        self.label = "default"
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        self.label = cast(str, state["label"])
+
+
+class FrozenListGetStateSubclass(FrozenList[object]):
+    def __init__(self) -> None:
+        super().__init__([1, 2, 3])
+        self.label = "getstate"
+
+    def __getstate__(self) -> dict[str, object]:
+        return {"label": self.label}
+
+
+class FrozenListSlotsStateSubclass(FrozenList[object]):
+    __slots__ = "label"
+
+    def __init__(self) -> None:
+        super().__init__([1, 2, 3])
+        self.label = "slot-state"
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        self.label = cast(str, state["label"])
+
+
+class FrozenListMutatingStateSubclass(FrozenList[object]):
+    def __init__(self) -> None:
+        super().__init__([1, 2, 3])
+        self.label = "mutating"
+        self.self_ref = self
+
+    def __getstate__(self) -> dict[str, object]:
+        return {
+            "items": list(self),
+            "label": self.label,
+            "self_ref": self.self_ref,
+        }
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        self.clear()
+        self.extend(cast(list[object], state["items"]))
+        self.label = cast(str, state["label"])
+        self.self_ref = cast(FrozenListMutatingStateSubclass, state["self_ref"])
+
+
 class FrozenListMixin:
     FrozenList = NotImplemented
 
@@ -500,6 +549,9 @@ class TestFrozenListPy(FrozenListMixin):
         (FrozenListSlotsSubclass, "slots", False),
         (FrozenListStateSubclass, "state", False),
         (FrozenListStateSubclass, "state", True),
+        (FrozenListDefaultStateSubclass, "default", False),
+        (FrozenListGetStateSubclass, "getstate", False),
+        (FrozenListSlotsStateSubclass, "slot-state", False),
     ],
 )
 def test_pickle_subclass(
@@ -513,6 +565,35 @@ def test_pickle_subclass(
     assert copied == orig
     assert copied.frozen is frozen
     assert cast(_Labeled, copied).label == label
+
+
+def test_deepcopy_returns_memoized_value() -> None:
+    orig = PyFrozenList([1, 2, 3])
+    marker = object()
+    deepcopy_method = cast(
+        Callable[[dict[int, object]], object], getattr(orig, "__deepcopy__")
+    )
+
+    assert deepcopy_method({id(orig): marker}) is marker
+
+
+@pytest.mark.parametrize("frozen", [False, True])
+def test_pickle_subclass_restores_custom_state_before_freezing(
+    frozen: bool,
+) -> None:
+    orig = FrozenListMutatingStateSubclass()
+    if frozen:
+        orig.freeze()
+
+    copied = cast(
+        FrozenListMutatingStateSubclass,
+        _PICKLE_LOADS(_PICKLE_DUMPS(orig)),
+    )
+
+    assert copied == orig
+    assert copied.frozen is frozen
+    assert copied.label == "mutating"
+    assert copied.self_ref is copied
 
 
 def test_unpickle_uses_pure_python(
@@ -533,6 +614,8 @@ def test_unpickle_uses_pure_python(
     assert get_state(frozen_list_type([1, 2, 3])) is None
     assert get_state(_EmptySlots()) is None
     assert get_state(FrozenListSubclass()) == ({"label": "subclass"}, {})
+    assert get_state(FrozenListDefaultStateSubclass()) == {"label": "default"}
+    assert get_state(FrozenListSlotsStateSubclass()) == {"label": "slot-state"}
     assert get_state(FrozenListStateSubclass()) == {
         "items": [1, 2, 3],
         "frozen": False,

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -2,6 +2,7 @@
 # mypy: disable-error-code="misc"
 
 import importlib
+import pickle
 import sys
 from collections.abc import MutableSequence
 from copy import copy, deepcopy
@@ -288,6 +289,21 @@ class FrozenListMixin:
         orig.append(4)
         assert len(orig) == 3
         assert len(copied) == 2
+
+    def test_pickle_unfrozen(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        orig = self.FrozenList([1, 2, 3])
+        monkeypatch.setattr(sys.modules["frozenlist"], "FrozenList", self.FrozenList)
+        copied = pickle.loads(pickle.dumps(orig))
+        assert copied == orig
+        assert not copied.frozen
+
+    def test_pickle_frozen(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        orig = self.FrozenList([1, 2, 3])
+        orig.freeze()
+        monkeypatch.setattr(sys.modules["frozenlist"], "FrozenList", self.FrozenList)
+        copied = pickle.loads(pickle.dumps(orig))
+        assert copied == orig
+        assert copied.frozen
 
     def test_deepcopy_unfrozen(self) -> None:
         orig = self.FrozenList([1, 2, 3])

--- a/tests/test_frozenlist.py
+++ b/tests/test_frozenlist.py
@@ -93,6 +93,19 @@ class FrozenListSlotsStateSubclass(FrozenList[object]):
         self.label = cast(str, state["label"])
 
 
+class FrozenListDictSlotsStateSubclass(FrozenList[object]):
+    __slots__ = ("slot_label", "__dict__")
+
+    def __init__(self) -> None:
+        super().__init__([1, 2, 3])
+        self.label = "dict"
+        self.slot_label = "slot"
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        self.label = cast(str, state["label"])
+        self.slot_label = cast(str, state["slot_label"])
+
+
 class FrozenListMutatingStateSubclass(FrozenList[object]):
     def __init__(self) -> None:
         super().__init__([1, 2, 3])
@@ -596,6 +609,18 @@ def test_pickle_subclass_restores_custom_state_before_freezing(
     assert copied.self_ref is copied
 
 
+def test_pickle_subclass_preserves_dict_and_slot_state() -> None:
+    orig = FrozenListDictSlotsStateSubclass()
+    copied = cast(
+        FrozenListDictSlotsStateSubclass,
+        _PICKLE_LOADS(_PICKLE_DUMPS(orig)),
+    )
+
+    assert copied == orig
+    assert copied.label == "dict"
+    assert copied.slot_label == "slot"
+
+
 def test_unpickle_uses_pure_python(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -616,6 +641,10 @@ def test_unpickle_uses_pure_python(
     assert get_state(FrozenListSubclass()) == ({"label": "subclass"}, {})
     assert get_state(FrozenListDefaultStateSubclass()) == {"label": "default"}
     assert get_state(FrozenListSlotsStateSubclass()) == {"label": "slot-state"}
+    assert get_state(FrozenListDictSlotsStateSubclass()) == {
+        "label": "dict",
+        "slot_label": "slot",
+    }
     assert get_state(FrozenListStateSubclass()) == {
         "items": [1, 2, 3],
         "frozen": False,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add an explicit pickle reducer to the Cython implementation so the atomic
frozen state is serialized through a small reconstruction helper.

## Are there changes in behavior for the user?

Yes. Pickling ``FrozenList`` instances works when the C extension is enabled,
for both frozen and unfrozen instances.

## Related issue number

Fixes #834

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (N/A; no documentation change is needed)
- [x] If you provide code modifications, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder

<details>
<summary>Agent run details</summary>

- The C-extension test suite passed: 116 tests, 100% coverage.
- The pure-Python test suite passed: 116 tests, 100% coverage.
- `ruff check frozenlist tests` passed.
- `flake8 frozenlist tests` passed.
- `cython-lint --no-pycodestyle frozenlist/_frozenlist.pyx` passed.
- `git diff --check` passed.

</details>

Drafted with OpenAI Codex; human review is required before marking this PR ready.
